### PR TITLE
chore(deps): update bun dependencies

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -7,7 +7,7 @@
         "@tailwindcss/forms": "^0.5.11",
         "@tailwindcss/postcss": "^4.3.0",
         "@vitejs/plugin-vue": "^6.0.7",
-        "axios": "^1.16.1",
+        "axios": "^1.17.0",
         "laravel-vite-plugin": "^3.1.0",
         "lodash": "^4.18.1",
         "postcss": "^8.5.15",

--- a/bun.lock
+++ b/bun.lock
@@ -197,7 +197,7 @@
 
     "asynckit": ["asynckit@0.4.0", "", {}, "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="],
 
-    "axios": ["axios@1.16.1", "", { "dependencies": { "follow-redirects": "^1.16.0", "form-data": "^4.0.5", "https-proxy-agent": "^5.0.1", "proxy-from-env": "^2.1.0" } }, "sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A=="],
+    "axios": ["axios@1.17.0", "", { "dependencies": { "follow-redirects": "^1.16.0", "form-data": "^4.0.5", "https-proxy-agent": "^5.0.1", "proxy-from-env": "^2.1.0" } }, "sha512-J8SwNxprqqpbfenehxWYXE7CW+wM1BB4w3+N+g+/Wx40xM4rsLrfPmHHxSWIxJLYDgSY/HqlFPIYb2/S3rxafw=="],
 
     "browserslist": ["browserslist@4.24.5", "", { "dependencies": { "caniuse-lite": "^1.0.30001716", "electron-to-chromium": "^1.5.149", "node-releases": "^2.0.19", "update-browserslist-db": "^1.1.3" }, "bin": { "browserslist": "cli.js" } }, "sha512-FDToo4Wo82hIdgc1CQ+NQD0hEhmpPjrZ3hiUgwgOG6IuTdlpr8jdjyG24P6cNP1yJpTLzS5OcGgSw0xmDU1/Tw=="],
 

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
         "@tailwindcss/forms": "^0.5.11",
         "@tailwindcss/postcss": "^4.3.0",
         "@vitejs/plugin-vue": "^6.0.7",
-        "axios": "^1.16.1",
+        "axios": "^1.17.0",
         "laravel-vite-plugin": "^3.1.0",
         "lodash": "^4.18.1",
         "postcss": "^8.5.15",


### PR DESCRIPTION
## Summary

Updates Bun-managed dependencies with `bun update`.

## Changed files

- bun.lock
- package.json

## bun update output

```text
[0.22ms] ".env"
bun update v1.3.14 (0d9b296a)
Resolving dependencies
Resolved, downloaded and extracted [32]
Saved lockfile

^ axios 1.16.1 -> 1.17.0

+ @tailwindcss/forms@0.5.11
+ @tailwindcss/postcss@4.3.0
+ @vitejs/plugin-vue@6.0.7
+ laravel-vite-plugin@3.1.0
+ lodash@4.18.1
+ postcss@8.5.15
+ tailwindcss@4.3.0
+ vite@8.0.16
+ vue@3.5.35
+ vue-loader@17.4.2

163 packages installed [709.00ms]
```

## Testing

- [ ] Not run; dependency update only
