### PR TITLE
Add redirect format dialog

### DIFF
--- a/src/lib/components/ui/dialog/dialog-close.svelte
+++ b/src/lib/components/ui/dialog/dialog-close.svelte
@@ -1,0 +1,16 @@
+<script lang="ts">
+    import { Dialog as DialogPrimitive } from "bits-ui";
+
+    let {
+        ref = $bindable(null),
+        type = "button",
+        ...restProps
+    }: DialogPrimitive.CloseProps = $props();
+</script>
+
+<DialogPrimitive.Close
+    bind:ref
+    data-slot="dialog-close"
+    {type}
+    {...restProps}
+/>

--- a/src/lib/components/ui/dialog/dialog-content.svelte
+++ b/src/lib/components/ui/dialog/dialog-content.svelte
@@ -1,0 +1,45 @@
+<script lang="ts">
+    import { Dialog as DialogPrimitive } from "bits-ui";
+    import { X } from "lucide-svelte";
+    import DialogOverlay from "./dialog-overlay.svelte";
+    import DialogPortal from "./dialog-portal.svelte";
+    import {
+        cn,
+        type WithoutChild,
+        type WithoutChildrenOrChild,
+    } from "$lib/utils.js";
+    import type { ComponentProps } from "svelte";
+
+    let {
+        ref = $bindable(null),
+        class: className,
+        portalProps,
+        children,
+        ...restProps
+    }: WithoutChild<DialogPrimitive.ContentProps> & {
+        portalProps?: WithoutChildrenOrChild<
+            ComponentProps<typeof DialogPortal>
+        >;
+    } = $props();
+</script>
+
+<DialogPortal {...portalProps}>
+    <DialogOverlay />
+    <DialogPrimitive.Content
+        bind:ref
+        data-slot="dialog-content"
+        class={cn(
+            "data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 fixed top-1/2 left-1/2 z-50 grid max-h-[min(88vh,760px)] w-[calc(100%-2rem)] -translate-x-1/2 -translate-y-1/2 gap-4 overflow-hidden rounded-lg bg-white p-4 text-zinc-950 shadow-xl ring-1 ring-zinc-950/10 duration-100 outline-none sm:p-5",
+            className,
+        )}
+        {...restProps}
+    >
+        {@render children?.()}
+        <DialogPrimitive.Close
+            class="absolute top-3 right-3 rounded-md p-1 text-zinc-500 transition hover:bg-zinc-100 hover:text-zinc-950 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-teal-600"
+        >
+            <X class="size-4" />
+            <span class="sr-only">Close</span>
+        </DialogPrimitive.Close>
+    </DialogPrimitive.Content>
+</DialogPortal>

--- a/src/lib/components/ui/dialog/dialog-description.svelte
+++ b/src/lib/components/ui/dialog/dialog-description.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+    import { Dialog as DialogPrimitive } from "bits-ui";
+    import { cn } from "$lib/utils.js";
+
+    let {
+        ref = $bindable(null),
+        class: className,
+        ...restProps
+    }: DialogPrimitive.DescriptionProps = $props();
+</script>
+
+<DialogPrimitive.Description
+    bind:ref
+    data-slot="dialog-description"
+    class={cn("text-base/7 text-zinc-600 sm:text-sm/6", className)}
+    {...restProps}
+/>

--- a/src/lib/components/ui/dialog/dialog-footer.svelte
+++ b/src/lib/components/ui/dialog/dialog-footer.svelte
@@ -1,0 +1,23 @@
+<script lang="ts">
+    import { cn, type WithElementRef } from "$lib/utils.js";
+    import type { HTMLAttributes } from "svelte/elements";
+
+    let {
+        ref = $bindable(null),
+        class: className,
+        children,
+        ...restProps
+    }: WithElementRef<HTMLAttributes<HTMLDivElement>> = $props();
+</script>
+
+<div
+    bind:this={ref}
+    data-slot="dialog-footer"
+    class={cn(
+        "flex flex-col-reverse gap-2 border-t border-zinc-200 pt-4 sm:flex-row sm:justify-end",
+        className,
+    )}
+    {...restProps}
+>
+    {@render children?.()}
+</div>

--- a/src/lib/components/ui/dialog/dialog-header.svelte
+++ b/src/lib/components/ui/dialog/dialog-header.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+    import { cn, type WithElementRef } from "$lib/utils.js";
+    import type { HTMLAttributes } from "svelte/elements";
+
+    let {
+        ref = $bindable(null),
+        class: className,
+        children,
+        ...restProps
+    }: WithElementRef<HTMLAttributes<HTMLDivElement>> = $props();
+</script>
+
+<div
+    bind:this={ref}
+    data-slot="dialog-header"
+    class={cn("grid gap-1.5 pr-8 text-left", className)}
+    {...restProps}
+>
+    {@render children?.()}
+</div>

--- a/src/lib/components/ui/dialog/dialog-overlay.svelte
+++ b/src/lib/components/ui/dialog/dialog-overlay.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+    import { Dialog as DialogPrimitive } from "bits-ui";
+    import { cn } from "$lib/utils.js";
+
+    let {
+        ref = $bindable(null),
+        class: className,
+        ...restProps
+    }: DialogPrimitive.OverlayProps = $props();
+</script>
+
+<DialogPrimitive.Overlay
+    bind:ref
+    data-slot="dialog-overlay"
+    class={cn(
+        "data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 fixed inset-0 z-50 bg-black/15 duration-100 supports-backdrop-filter:backdrop-blur-xs",
+        className,
+    )}
+    {...restProps}
+/>

--- a/src/lib/components/ui/dialog/dialog-portal.svelte
+++ b/src/lib/components/ui/dialog/dialog-portal.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+    import { Dialog as DialogPrimitive } from "bits-ui";
+
+    let { ...restProps }: DialogPrimitive.PortalProps = $props();
+</script>
+
+<DialogPrimitive.Portal {...restProps} />

--- a/src/lib/components/ui/dialog/dialog-title.svelte
+++ b/src/lib/components/ui/dialog/dialog-title.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+    import { Dialog as DialogPrimitive } from "bits-ui";
+    import { cn } from "$lib/utils.js";
+
+    let {
+        ref = $bindable(null),
+        class: className,
+        ...restProps
+    }: DialogPrimitive.TitleProps = $props();
+</script>
+
+<DialogPrimitive.Title
+    bind:ref
+    data-slot="dialog-title"
+    class={cn("text-lg/7 font-semibold text-zinc-950", className)}
+    {...restProps}
+/>

--- a/src/lib/components/ui/dialog/dialog-trigger.svelte
+++ b/src/lib/components/ui/dialog/dialog-trigger.svelte
@@ -1,0 +1,8 @@
+<script lang="ts">
+    import { Dialog as DialogPrimitive } from "bits-ui";
+
+    let { ref = $bindable(null), ...restProps }: DialogPrimitive.TriggerProps =
+        $props();
+</script>
+
+<DialogPrimitive.Trigger bind:ref data-slot="dialog-trigger" {...restProps} />

--- a/src/lib/components/ui/dialog/dialog.svelte
+++ b/src/lib/components/ui/dialog/dialog.svelte
@@ -1,0 +1,8 @@
+<script lang="ts">
+    import { Dialog as DialogPrimitive } from "bits-ui";
+
+    let { open = $bindable(false), ...restProps }: DialogPrimitive.RootProps =
+        $props();
+</script>
+
+<DialogPrimitive.Root bind:open {...restProps} />

--- a/src/lib/components/ui/dialog/index.ts
+++ b/src/lib/components/ui/dialog/index.ts
@@ -1,0 +1,34 @@
+import Root from "./dialog.svelte";
+import Trigger from "./dialog-trigger.svelte";
+import Portal from "./dialog-portal.svelte";
+import Overlay from "./dialog-overlay.svelte";
+import Content from "./dialog-content.svelte";
+import Header from "./dialog-header.svelte";
+import Footer from "./dialog-footer.svelte";
+import Title from "./dialog-title.svelte";
+import Description from "./dialog-description.svelte";
+import Close from "./dialog-close.svelte";
+
+export {
+    Root,
+    Trigger,
+    Portal,
+    Overlay,
+    Content,
+    Header,
+    Footer,
+    Title,
+    Description,
+    Close,
+    //
+    Root as Dialog,
+    Trigger as DialogTrigger,
+    Portal as DialogPortal,
+    Overlay as DialogOverlay,
+    Content as DialogContent,
+    Header as DialogHeader,
+    Footer as DialogFooter,
+    Title as DialogTitle,
+    Description as DialogDescription,
+    Close as DialogClose,
+};

--- a/src/lib/server/redirects.ts
+++ b/src/lib/server/redirects.ts
@@ -9,6 +9,21 @@ type UrlLike = {
     redirectTo: string | null;
 };
 
+type RedirectFormat = {
+    id: string;
+    label: string;
+    filename: string;
+    body: string;
+};
+
+type RedirectRule = {
+    sourcePath: string;
+    sourceQuery: string;
+    sourceQueryMatchers: string[];
+    sourcePathWithQuery: string;
+    targetPathWithQuery: string;
+};
+
 export function normalizeUrlInput(url: string) {
     const withoutHash = url.trim().split("#")[0] ?? "";
     if (!withoutHash) return "";
@@ -50,33 +65,159 @@ export function getDevRedirectUrl(batch: BatchLike, url: UrlLike) {
     return next.toString();
 }
 
-export function getRewrite(batch: BatchLike, url: UrlLike) {
+function escapeApacheRegex(value: string) {
+    return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function escapeApacheTarget(value: string) {
+    return value.replaceAll("%20", "\\ ");
+}
+
+function escapeNginxQuoted(value: string) {
+    return value.replaceAll("\\", "\\\\").replaceAll('"', '\\"');
+}
+
+function normalizeRedirectTarget(batch: BatchLike, url: UrlLike) {
+    return new URL(getDevRedirectUrl(batch, url));
+}
+
+function getRedirectRule(batch: BatchLike, url: UrlLike): RedirectRule {
     const current = new URL(url.url);
-    const queryString = current.searchParams.toString();
-    const path = current.pathname.replace(/^\//, "");
+    const target = normalizeRedirectTarget(batch, url);
+    const sourceQuery = current.searchParams.toString();
+    const sourcePathWithQuery = `${current.pathname}${current.search}`;
+    const targetPathWithQuery = `${target.pathname}${target.search}`;
+
+    return {
+        sourcePath: current.pathname,
+        sourceQuery,
+        sourceQueryMatchers: sourceQuery ? sourceQuery.split("&") : [],
+        sourcePathWithQuery,
+        targetPathWithQuery,
+    };
+}
+
+export function getApacheRewrite(batch: BatchLike, url: UrlLike) {
+    const rule = getRedirectRule(batch, url);
+    const path = rule.sourcePath.replace(/^\//, "");
     let pattern = "(.*) ";
 
     if (path) {
-        const escaped = path.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+        const escaped = escapeApacheRegex(path);
         pattern = `^${escaped}${path.endsWith("/") ? "?" : ""}$ `;
     }
 
-    let rule = "";
-    if (queryString) {
-        rule += `RewriteCond %{QUERY_STRING} ${queryString}\n`;
+    const flags = ["R=301", "NC", "L"];
+    if (!rule.targetPathWithQuery.includes("?")) {
+        flags.push("QSD");
     }
 
-    rule += `RewriteRule ${pattern}${getDevRedirectUrl(batch, url)}? [R=301,NC,L]`;
+    let rewrite = "";
+    if (rule.sourceQuery) {
+        rewrite += `RewriteCond %{QUERY_STRING} ^${escapeApacheRegex(rule.sourceQuery)}$ [NC]\n`;
+    }
 
-    const devUrlWithSlash = batch.devUrl.endsWith("/")
-        ? batch.devUrl
-        : `${batch.devUrl}/`;
+    rewrite += `RewriteRule ${pattern}${escapeApacheTarget(rule.targetPathWithQuery)} [${flags.join(",")}]`;
 
-    return rule
-        .replaceAll(devUrlWithSlash, "/")
-        .replaceAll(batch.devUrl, "")
-        .replaceAll("%20", "\\ ")
-        .replaceAll(" ? ", " /? ");
+    return rewrite;
+}
+
+export function getRewrite(batch: BatchLike, url: UrlLike) {
+    return getApacheRewrite(batch, url);
+}
+
+function getNginxRedirect(batch: BatchLike, url: UrlLike) {
+    const rule = getRedirectRule(batch, url);
+    const target = escapeNginxQuoted(rule.targetPathWithQuery);
+
+    if (rule.sourceQuery) {
+        return [
+            `location = ${rule.sourcePath} {`,
+            `    if ($args = "${escapeNginxQuoted(rule.sourceQuery)}") {`,
+            `        return 301 ${target};`,
+            "    }",
+            "}",
+        ].join("\n");
+    }
+
+    return [
+        `location = ${rule.sourcePath} {`,
+        `    return 301 ${target};`,
+        "}",
+    ].join("\n");
+}
+
+function getCaddyRedirect(batch: BatchLike, url: UrlLike, index: number) {
+    const rule = getRedirectRule(batch, url);
+    if (!rule.sourceQuery) {
+        return `redir ${rule.sourcePath} ${rule.targetPathWithQuery} permanent`;
+    }
+
+    const queryMatchers = rule.sourceQueryMatchers.join(" ");
+
+    return [
+        `@redirect_${index + 1} {`,
+        `    path ${rule.sourcePath}`,
+        `    query ${queryMatchers}`,
+        "}",
+        `redir @redirect_${index + 1} ${rule.targetPathWithQuery} permanent`,
+    ].join("\n");
+}
+
+function getNetlifyRedirect(batch: BatchLike, url: UrlLike) {
+    const rule = getRedirectRule(batch, url);
+    const queryParams = rule.sourceQueryMatchers.join(" ");
+    const source = [rule.sourcePath, queryParams].filter(Boolean).join(" ");
+
+    return `${source} ${rule.targetPathWithQuery} 301!`;
+}
+
+export function getRedirectFormats(batch: BatchLike, redirectUrls: UrlLike[]) {
+    const sortedUrls = [...redirectUrls].sort((a, b) => {
+        const aRule = getRedirectRule(batch, a);
+        const bRule = getRedirectRule(batch, b);
+        return (
+            bRule.sourcePathWithQuery.length -
+                aRule.sourcePathWithQuery.length ||
+            aRule.sourcePathWithQuery.localeCompare(bRule.sourcePathWithQuery)
+        );
+    });
+
+    const apacheRules = sortedUrls.map((url) => getApacheRewrite(batch, url));
+    const nginxRules = sortedUrls.map((url) => getNginxRedirect(batch, url));
+    const caddyRules = sortedUrls.map((url, index) =>
+        getCaddyRedirect(batch, url, index),
+    );
+    const netlifyRules = sortedUrls.map((url) =>
+        getNetlifyRedirect(batch, url),
+    );
+
+    return [
+        {
+            id: "apache",
+            label: "Apache .htaccess",
+            filename: ".htaccess",
+            body: ["RewriteEngine On", ...apacheRules].join("\n"),
+        },
+        {
+            id: "nginx",
+            label: "nginx",
+            filename: "redirects.conf",
+            body: nginxRules.join("\n\n"),
+        },
+        {
+            id: "caddy",
+            label: "Caddyfile",
+            filename: "Caddyfile",
+            body: caddyRules.join("\n\n"),
+        },
+        {
+            id: "netlify",
+            label: "Netlify _redirects",
+            filename: "_redirects",
+            body: netlifyRules.join("\n"),
+        },
+    ] satisfies RedirectFormat[];
 }
 
 export async function checkUrl(url: string): Promise<HttpResponse> {

--- a/src/lib/server/redirects.ts
+++ b/src/lib/server/redirects.ts
@@ -84,7 +84,9 @@ function normalizeRedirectTarget(batch: BatchLike, url: UrlLike) {
 function getRedirectRule(batch: BatchLike, url: UrlLike): RedirectRule {
     const current = new URL(url.url);
     const target = normalizeRedirectTarget(batch, url);
-    const sourceQuery = current.searchParams.toString();
+    const sourceQuery = current.search.startsWith("?")
+        ? current.search.slice(1)
+        : "";
     const sourcePathWithQuery = `${current.pathname}${current.search}`;
     const targetPathWithQuery = `${target.pathname}${target.search}`;
 
@@ -100,7 +102,7 @@ function getRedirectRule(batch: BatchLike, url: UrlLike): RedirectRule {
 export function getApacheRewrite(batch: BatchLike, url: UrlLike) {
     const rule = getRedirectRule(batch, url);
     const path = rule.sourcePath.replace(/^\//, "");
-    let pattern = "(.*) ";
+    let pattern = "^$ ";
 
     if (path) {
         const escaped = escapeApacheRegex(path);
@@ -132,10 +134,8 @@ function getNginxRedirect(batch: BatchLike, url: UrlLike) {
 
     if (rule.sourceQuery) {
         return [
-            `location = ${rule.sourcePath} {`,
-            `    if ($args = "${escapeNginxQuoted(rule.sourceQuery)}") {`,
-            `        return 301 ${target};`,
-            "    }",
+            `if ($request_uri = "${escapeNginxQuoted(rule.sourcePathWithQuery)}") {`,
+            `    return 301 ${target};`,
             "}",
         ].join("\n");
     }

--- a/src/routes/api/batches/[id]/redirects/+server.ts
+++ b/src/routes/api/batches/[id]/redirects/+server.ts
@@ -1,7 +1,7 @@
-import { getRewrite } from "$lib/server/redirects";
+import { getRedirectFormats } from "$lib/server/redirects";
 import { db } from "$lib/server/db";
 import { batches, urls } from "$lib/server/schema";
-import { error, redirect, text } from "@sveltejs/kit";
+import { error, json, redirect } from "@sveltejs/kit";
 import { and, eq, isNull, isNotNull } from "drizzle-orm";
 
 export async function GET({ locals, params }) {
@@ -30,13 +30,8 @@ export async function GET({ locals, params }) {
         ),
     });
 
-    const rewrites = pendingUrls
-        .map((url) => getRewrite(batch, url))
-        .sort((a, b) => b.length - a.length || a.localeCompare(b));
-
-    return text(["RewriteEngine On", ...rewrites].join("\n"), {
-        headers: {
-            "content-type": "text/plain; charset=utf-8",
-        },
+    return json({
+        formats: getRedirectFormats(batch, pendingUrls),
+        count: pendingUrls.length,
     });
 }

--- a/src/routes/batch/[id]/+page.svelte
+++ b/src/routes/batch/[id]/+page.svelte
@@ -1,11 +1,27 @@
 <script lang="ts">
     import * as AlertDialog from "$lib/components/ui/alert-dialog/index.js";
+    import * as Dialog from "$lib/components/ui/dialog/index.js";
     import Badge from "$lib/components/ui/badge.svelte";
     import Button from "$lib/components/ui/button.svelte";
     import Input from "$lib/components/ui/input.svelte";
     import Textarea from "$lib/components/ui/textarea.svelte";
     import { enhance } from "$app/forms";
-    import { ExternalLink, Eye, EyeOff, RotateCw, Trash2 } from "lucide-svelte";
+    import {
+        Check,
+        Clipboard,
+        Eye,
+        EyeOff,
+        FileText,
+        RotateCw,
+        Trash2,
+    } from "lucide-svelte";
+
+    type RedirectFormat = {
+        id: string;
+        label: string;
+        filename: string;
+        body: string;
+    };
 
     let { data, form } = $props();
 
@@ -14,9 +30,24 @@
     let checkingAll = $state(false);
     let checkMessage = $state("");
     let urlRows = $state<typeof data.urls>([]);
+    let redirectsOpen = $state(false);
+    let redirectsLoading = $state(false);
+    let redirectsError = $state("");
+    let redirectFormats = $state<RedirectFormat[]>([]);
+    let selectedFormatId = $state("apache");
+    let copyMessage = $state("");
+    let redirectCount = $state(0);
 
     $effect(() => {
         urlRows = data.urls;
+    });
+
+    $effect(() => {
+        if (redirectsOpen) {
+            void loadRedirects();
+        } else {
+            copyMessage = "";
+        }
     });
 
     const validDevUrl = $derived(Boolean(data.batch.devUrl));
@@ -33,6 +64,80 @@
             return true;
         }),
     );
+    const selectedFormat = $derived(
+        redirectFormats.find((format) => format.id === selectedFormatId) ??
+            redirectFormats[0],
+    );
+
+    async function loadRedirects() {
+        redirectsLoading = true;
+        redirectsError = "";
+        copyMessage = "";
+
+        try {
+            const response = await fetch(
+                `/api/batches/${data.batch.id}/redirects`,
+            );
+            if (!response.ok) {
+                redirectsError = "Could not load redirects.";
+                return;
+            }
+
+            const payload = (await response.json()) as {
+                formats: RedirectFormat[];
+                count: number;
+            };
+            redirectFormats = payload.formats;
+            redirectCount = payload.count;
+            if (
+                !payload.formats.some(
+                    (format) => format.id === selectedFormatId,
+                )
+            ) {
+                selectedFormatId = payload.formats[0]?.id ?? "apache";
+            }
+        } catch {
+            redirectsError = "Could not load redirects.";
+        } finally {
+            redirectsLoading = false;
+        }
+    }
+
+    function selectRedirectFormat(id: string) {
+        selectedFormatId = id;
+        copyMessage = "";
+    }
+
+    function copyWithFallback(text: string) {
+        const textarea = document.createElement("textarea");
+        textarea.value = text;
+        textarea.setAttribute("readonly", "");
+        textarea.style.position = "fixed";
+        textarea.style.left = "-9999px";
+        document.body.append(textarea);
+        textarea.select();
+        const copied = document.execCommand("copy");
+        textarea.remove();
+
+        if (!copied) {
+            throw new Error("Copy command failed");
+        }
+    }
+
+    async function copySelectedRedirects() {
+        if (!selectedFormat) return;
+
+        try {
+            if (navigator.clipboard?.writeText) {
+                await navigator.clipboard.writeText(selectedFormat.body);
+            } else {
+                copyWithFallback(selectedFormat.body);
+            }
+            copyMessage = "Copied";
+        } catch {
+            copyMessage = "Copy failed";
+        }
+    }
 
     async function recheck(id: number) {
         const response = await fetch(`/api/urls/${id}/check`, {
@@ -110,13 +215,83 @@
         </div>
 
         {#if validDevUrl}
-            <a
-                href={`/api/batches/${data.batch.id}/redirects`}
-                target="_blank"
-                class="inline-flex items-center justify-center gap-1.5 rounded-md bg-white px-3 py-2 text-base/6 font-medium text-zinc-900 ring-1 ring-zinc-200 hover:bg-zinc-50 sm:py-1.5 sm:text-sm/6"
-            >
-                View rewrites <ExternalLink class="size-5 sm:size-4" />
-            </a>
+            <Dialog.Root bind:open={redirectsOpen}>
+                <Dialog.Trigger
+                    class="inline-flex items-center justify-center gap-1.5 rounded-md bg-white px-3 py-2 text-base/6 font-medium text-zinc-900 ring-1 ring-zinc-200 transition hover:bg-zinc-50 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-teal-600 sm:py-1.5 sm:text-sm/6"
+                >
+                    View redirects <FileText class="size-5 sm:size-4" />
+                </Dialog.Trigger>
+                <Dialog.Content class="sm:max-w-4xl">
+                    <Dialog.Header>
+                        <Dialog.Title>Redirects</Dialog.Title>
+                        <Dialog.Description>
+                            {redirectCount} pending URL{redirectCount === 1
+                                ? ""
+                                : "s"} with redirect targets.
+                        </Dialog.Description>
+                    </Dialog.Header>
+
+                    {#if redirectsLoading}
+                        <div
+                            class="rounded-md bg-zinc-50 px-4 py-8 text-center text-base/7 text-zinc-600 ring-1 ring-zinc-200 sm:text-sm/6"
+                        >
+                            Loading redirects...
+                        </div>
+                    {:else if redirectsError}
+                        <div
+                            class="rounded-md bg-red-50 px-4 py-3 text-base/7 text-red-800 ring-1 ring-red-200 sm:text-sm/6"
+                        >
+                            {redirectsError}
+                        </div>
+                    {:else if selectedFormat}
+                        <div class="flex flex-wrap gap-2">
+                            {#each redirectFormats as format}
+                                <button
+                                    type="button"
+                                    aria-pressed={selectedFormatId ===
+                                        format.id}
+                                    class={`rounded-md px-3 py-2 text-base/6 font-medium ring-1 transition focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-teal-600 sm:py-1.5 sm:text-sm/6 ${
+                                        selectedFormatId === format.id
+                                            ? "bg-teal-700 text-white ring-teal-700"
+                                            : "bg-white text-zinc-900 ring-zinc-200 hover:bg-zinc-50"
+                                    }`}
+                                    onclick={() =>
+                                        selectRedirectFormat(format.id)}
+                                >
+                                    {format.label}
+                                </button>
+                            {/each}
+                        </div>
+
+                        <div class="min-h-0 overflow-hidden">
+                            <div
+                                class="mb-2 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between"
+                            >
+                                <span
+                                    class="font-mono text-base/7 text-zinc-600 sm:text-sm/6"
+                                >
+                                    {selectedFormat.filename}
+                                </span>
+                                <Button
+                                    type="button"
+                                    onclick={copySelectedRedirects}
+                                >
+                                    {#if copyMessage === "Copied"}
+                                        <Check class="size-5 sm:size-4" />
+                                    {:else}
+                                        <Clipboard class="size-5 sm:size-4" />
+                                    {/if}
+                                    {copyMessage || "Copy to clipboard"}
+                                </Button>
+                            </div>
+                            <pre
+                                class="max-h-[52vh] min-h-72 overflow-auto rounded-md bg-zinc-950 p-4 text-sm/6 whitespace-pre-wrap text-zinc-50 ring-1 ring-zinc-950/10"><code
+                                    >{selectedFormat.body}</code
+                                ></pre>
+                        </div>
+                    {/if}
+                </Dialog.Content>
+            </Dialog.Root>
         {/if}
     </div>
 


### PR DESCRIPTION
## Summary

Adds a redirects dialog to the batch view and expands generated redirect output beyond Apache.

## Changes

- Generate redirect formats for Apache `.htaccess`, nginx, Caddyfile, and Netlify `_redirects` from the shared server formatter.
- Return redirect formats as JSON from the batch redirects API.
- Replace the old new-tab "View rewrites" flow with a shadcn-style dialog labeled "View redirects".
- Add format selection and a copy-to-clipboard action for the selected redirect output.
- Add reusable dialog UI primitives under `src/lib/components/ui/dialog`.

## Validation

- `bun run check`
- `bun run lint`
- `bun run build`
- Formatter smoke test for path and query-string redirect output

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a suite of dialog UI components (header, footer, title, description, overlay, portal, trigger, content, close) for consistent in-app modals.
  * Added an in-app Redirects dialog on the batch page with format selection and copy-to-clipboard for multiple redirect formats.
  * Redirect API now returns structured format data (JSON) for client consumption.

* **Refactor**
  * Reworked redirect generation to produce platform-specific formats (Apache, Nginx, Caddy, Netlify).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->