### PR TITLE
Collect Dev URL in a drawer when creating a batch

### DIFF
--- a/src/lib/components/ui/sheet/index.ts
+++ b/src/lib/components/ui/sheet/index.ts
@@ -1,0 +1,34 @@
+import Root from "./sheet.svelte";
+import Portal from "./sheet-portal.svelte";
+import Title from "./sheet-title.svelte";
+import Footer from "./sheet-footer.svelte";
+import Header from "./sheet-header.svelte";
+import Overlay from "./sheet-overlay.svelte";
+import Content from "./sheet-content.svelte";
+import Description from "./sheet-description.svelte";
+import Trigger from "./sheet-trigger.svelte";
+import Close from "./sheet-close.svelte";
+
+export {
+    Root,
+    Title,
+    Portal,
+    Footer,
+    Header,
+    Trigger,
+    Overlay,
+    Content,
+    Description,
+    Close,
+    //
+    Root as Sheet,
+    Title as SheetTitle,
+    Portal as SheetPortal,
+    Footer as SheetFooter,
+    Header as SheetHeader,
+    Trigger as SheetTrigger,
+    Overlay as SheetOverlay,
+    Content as SheetContent,
+    Description as SheetDescription,
+    Close as SheetClose,
+};

--- a/src/lib/components/ui/sheet/sheet-close.svelte
+++ b/src/lib/components/ui/sheet/sheet-close.svelte
@@ -1,0 +1,11 @@
+<script lang="ts">
+    import { Dialog as SheetPrimitive } from "bits-ui";
+
+    let {
+        ref = $bindable(null),
+        type = "button",
+        ...restProps
+    }: SheetPrimitive.CloseProps = $props();
+</script>
+
+<SheetPrimitive.Close bind:ref data-slot="sheet-close" {type} {...restProps} />

--- a/src/lib/components/ui/sheet/sheet-content.svelte
+++ b/src/lib/components/ui/sheet/sheet-content.svelte
@@ -1,0 +1,55 @@
+<script lang="ts">
+    import { Dialog as SheetPrimitive } from "bits-ui";
+    import SheetOverlay from "./sheet-overlay.svelte";
+    import SheetPortal from "./sheet-portal.svelte";
+    import type { Snippet } from "svelte";
+    import { cn, type WithoutChildrenOrChild } from "$lib/utils.js";
+    import type { ComponentProps } from "svelte";
+    import { Button } from "$lib/components/ui/button/index.js";
+    import XIcon from "@lucide/svelte/icons/x";
+
+    let {
+        ref = $bindable(null),
+        class: className,
+        portalProps,
+        children,
+        showCloseButton = true,
+        ...restProps
+    }: WithoutChildrenOrChild<SheetPrimitive.ContentProps> & {
+        portalProps?: WithoutChildrenOrChild<
+            ComponentProps<typeof SheetPortal>
+        >;
+        children: Snippet;
+        showCloseButton?: boolean;
+    } = $props();
+</script>
+
+<SheetPortal {...portalProps}>
+    <SheetOverlay />
+    <SheetPrimitive.Content
+        bind:ref
+        data-slot="sheet-content"
+        class={cn(
+            "bg-popover text-popover-foreground data-open:animate-in data-closed:animate-out data-closed:slide-out-to-right data-open:slide-in-from-right ring-foreground/5 dark:ring-foreground/10 fixed inset-y-0 right-0 z-50 flex h-full w-3/4 flex-col gap-6 overflow-y-auto p-6 text-sm shadow-xl ring-1 duration-200 outline-none sm:max-w-md",
+            className,
+        )}
+        {...restProps}
+    >
+        {@render children?.()}
+        {#if showCloseButton}
+            <SheetPrimitive.Close data-slot="sheet-close">
+                {#snippet child({ props })}
+                    <Button
+                        variant="ghost"
+                        class="bg-secondary absolute top-4 right-4"
+                        size="icon-sm"
+                        {...props}
+                    >
+                        <XIcon />
+                        <span class="sr-only">Close</span>
+                    </Button>
+                {/snippet}
+            </SheetPrimitive.Close>
+        {/if}
+    </SheetPrimitive.Content>
+</SheetPortal>

--- a/src/lib/components/ui/sheet/sheet-description.svelte
+++ b/src/lib/components/ui/sheet/sheet-description.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+    import { Dialog as SheetPrimitive } from "bits-ui";
+    import { cn } from "$lib/utils.js";
+
+    let {
+        ref = $bindable(null),
+        class: className,
+        ...restProps
+    }: SheetPrimitive.DescriptionProps = $props();
+</script>
+
+<SheetPrimitive.Description
+    bind:ref
+    data-slot="sheet-description"
+    class={cn(
+        "text-muted-foreground *:[a]:hover:text-foreground text-sm *:[a]:underline *:[a]:underline-offset-3",
+        className,
+    )}
+    {...restProps}
+/>

--- a/src/lib/components/ui/sheet/sheet-footer.svelte
+++ b/src/lib/components/ui/sheet/sheet-footer.svelte
@@ -1,0 +1,35 @@
+<script lang="ts">
+    import { cn, type WithElementRef } from "$lib/utils.js";
+    import type { HTMLAttributes } from "svelte/elements";
+    import { Dialog as SheetPrimitive } from "bits-ui";
+    import { Button } from "$lib/components/ui/button/index.js";
+
+    let {
+        ref = $bindable(null),
+        class: className,
+        children,
+        showCloseButton = false,
+        ...restProps
+    }: WithElementRef<HTMLAttributes<HTMLDivElement>> & {
+        showCloseButton?: boolean;
+    } = $props();
+</script>
+
+<div
+    bind:this={ref}
+    data-slot="sheet-footer"
+    class={cn(
+        "mt-auto flex flex-col-reverse gap-2 sm:flex-row sm:justify-end",
+        className,
+    )}
+    {...restProps}
+>
+    {@render children?.()}
+    {#if showCloseButton}
+        <SheetPrimitive.Close>
+            {#snippet child({ props })}
+                <Button variant="outline" {...props}>Close</Button>
+            {/snippet}
+        </SheetPrimitive.Close>
+    {/if}
+</div>

--- a/src/lib/components/ui/sheet/sheet-header.svelte
+++ b/src/lib/components/ui/sheet/sheet-header.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+    import type { HTMLAttributes } from "svelte/elements";
+    import { cn, type WithElementRef } from "$lib/utils.js";
+
+    let {
+        ref = $bindable(null),
+        class: className,
+        children,
+        ...restProps
+    }: WithElementRef<HTMLAttributes<HTMLDivElement>> = $props();
+</script>
+
+<div
+    bind:this={ref}
+    data-slot="sheet-header"
+    class={cn("flex flex-col gap-1.5", className)}
+    {...restProps}
+>
+    {@render children?.()}
+</div>

--- a/src/lib/components/ui/sheet/sheet-overlay.svelte
+++ b/src/lib/components/ui/sheet/sheet-overlay.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+    import { Dialog as SheetPrimitive } from "bits-ui";
+    import { cn } from "$lib/utils.js";
+
+    let {
+        ref = $bindable(null),
+        class: className,
+        ...restProps
+    }: SheetPrimitive.OverlayProps = $props();
+</script>
+
+<SheetPrimitive.Overlay
+    bind:ref
+    data-slot="sheet-overlay"
+    class={cn(
+        "data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 fixed inset-0 isolate z-50 bg-black/30 duration-200 supports-backdrop-filter:backdrop-blur-sm",
+        className,
+    )}
+    {...restProps}
+/>

--- a/src/lib/components/ui/sheet/sheet-portal.svelte
+++ b/src/lib/components/ui/sheet/sheet-portal.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+    import { Dialog as SheetPrimitive } from "bits-ui";
+
+    let { ...restProps }: SheetPrimitive.PortalProps = $props();
+</script>
+
+<SheetPrimitive.Portal {...restProps} />

--- a/src/lib/components/ui/sheet/sheet-title.svelte
+++ b/src/lib/components/ui/sheet/sheet-title.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+    import { Dialog as SheetPrimitive } from "bits-ui";
+    import { cn } from "$lib/utils.js";
+
+    let {
+        ref = $bindable(null),
+        class: className,
+        ...restProps
+    }: SheetPrimitive.TitleProps = $props();
+</script>
+
+<SheetPrimitive.Title
+    bind:ref
+    data-slot="sheet-title"
+    class={cn("text-base leading-none font-medium", className)}
+    {...restProps}
+/>

--- a/src/lib/components/ui/sheet/sheet-trigger.svelte
+++ b/src/lib/components/ui/sheet/sheet-trigger.svelte
@@ -1,0 +1,16 @@
+<script lang="ts">
+    import { Dialog as SheetPrimitive } from "bits-ui";
+
+    let {
+        ref = $bindable(null),
+        type = "button",
+        ...restProps
+    }: SheetPrimitive.TriggerProps = $props();
+</script>
+
+<SheetPrimitive.Trigger
+    bind:ref
+    data-slot="sheet-trigger"
+    {type}
+    {...restProps}
+/>

--- a/src/lib/components/ui/sheet/sheet.svelte
+++ b/src/lib/components/ui/sheet/sheet.svelte
@@ -1,0 +1,8 @@
+<script lang="ts">
+    import { Dialog as SheetPrimitive } from "bits-ui";
+
+    let { open = $bindable(false), ...restProps }: SheetPrimitive.RootProps =
+        $props();
+</script>
+
+<SheetPrimitive.Root bind:open {...restProps} />

--- a/src/routes/+page.server.ts
+++ b/src/routes/+page.server.ts
@@ -1,5 +1,6 @@
 import { db } from "$lib/server/db";
 import { batches, urls } from "$lib/server/schema";
+import { isValidHttpUrl } from "$lib/server/redirects";
 import { fail, redirect } from "@sveltejs/kit";
 import { and, count, eq, isNull, sql } from "drizzle-orm";
 
@@ -35,14 +36,24 @@ export async function load({ locals }) {
 }
 
 export const actions = {
-    create: async ({ locals }) => {
+    create: async ({ locals, request }) => {
         if (!locals.user) {
-            return fail(401, { message: "You must be signed in." });
+            return fail(401, { devUrl: "", message: "You must be signed in." });
+        }
+
+        const formData = await request.formData();
+        const devUrl = String(formData.get("devUrl") ?? "").trim();
+
+        if (!isValidHttpUrl(devUrl)) {
+            return fail(400, {
+                devUrl,
+                message: "Enter a valid dev URL including http:// or https://.",
+            });
         }
 
         const [batch] = await db
             .insert(batches)
-            .values({ userId: locals.user.id })
+            .values({ userId: locals.user.id, devUrl })
             .returning({ id: batches.id });
 
         throw redirect(303, `/batch/${batch.id}`);

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,9 +1,15 @@
 <script lang="ts">
+    import { enhance } from "$app/forms";
     import Badge from "$lib/components/ui/badge/badge.svelte";
     import Button from "$lib/components/ui/button/button.svelte";
+    import Input from "$lib/components/ui/input/input.svelte";
+    import * as Sheet from "$lib/components/ui/sheet/index.js";
     import { ExternalLink, Plus } from "lucide-svelte";
 
-    let { data } = $props();
+    let { data, form } = $props();
+
+    let createOpen = $state(false);
+    let creating = $state(false);
 
     function screenshotUrl(devUrl: string) {
         const url = new URL(
@@ -31,11 +37,71 @@
                 Manage redirect checks and Apache rewrite output.
             </p>
         </div>
-        <form method="POST" action="?/create">
-            <Button type="submit"
-                ><Plus class="size-5 sm:size-4" /> New batch</Button
-            >
-        </form>
+        <Sheet.Root bind:open={createOpen}>
+            <Sheet.Trigger>
+                {#snippet child({ props })}
+                    <Button {...props}>
+                        <Plus class="size-5 sm:size-4" /> New batch
+                    </Button>
+                {/snippet}
+            </Sheet.Trigger>
+            <Sheet.Content>
+                <Sheet.Header>
+                    <Sheet.Title>New redirect batch</Sheet.Title>
+                    <Sheet.Description>
+                        Enter the Dev URL — the site where you're actively
+                        working on the redirects. You'll add the redirects to
+                        check after creating the batch.
+                    </Sheet.Description>
+                </Sheet.Header>
+
+                <form
+                    method="POST"
+                    action="?/create"
+                    class="flex flex-1 flex-col gap-6"
+                    use:enhance={() => {
+                        creating = true;
+                        return async ({ update }) => {
+                            await update();
+                            creating = false;
+                        };
+                    }}
+                >
+                    <div class="space-y-1.5">
+                        <label
+                            for="new-batch-dev-url"
+                            class="block text-base/6 font-medium text-zinc-900 sm:text-sm/6"
+                        >
+                            Dev URL
+                        </label>
+                        <Input
+                            id="new-batch-dev-url"
+                            name="devUrl"
+                            type="url"
+                            value={form?.devUrl ?? ""}
+                            placeholder="https://www.example.test"
+                            autocomplete="off"
+                            required
+                        />
+                        <p class="text-sm/6 text-zinc-500">
+                            The staging or development site where you're
+                            actively working on the redirects.
+                        </p>
+                        {#if form?.message}
+                            <p class="text-sm/6 text-red-600">
+                                {form.message}
+                            </p>
+                        {/if}
+                    </div>
+
+                    <Sheet.Footer showCloseButton>
+                        <Button type="submit" disabled={creating}>
+                            {creating ? "Creating…" : "Create batch"}
+                        </Button>
+                    </Sheet.Footer>
+                </form>
+            </Sheet.Content>
+        </Sheet.Root>
     </div>
 
     {#if data.batches.length}


### PR DESCRIPTION
## What changed

The **New batch** button now opens a slide-in drawer that prompts for the Dev URL before the batch is created, instead of immediately creating an empty batch and redirecting to it.

- Added a `Sheet` (drawer) component under `src/lib/components/ui/sheet/`, built on the same `bits-ui` Dialog primitive as the existing dialog so it matches the Luma design system. It slides in from the right.
- The drawer explains that the **Dev URL** is the staging/development site where you're actively working on the redirects (title, description, and helper text).
- The `create` action now reads and validates `devUrl` (reusing `isValidHttpUrl`), returns a `fail` with an inline error on invalid input, and persists the URL on insert before redirecting to `/batch/[id]`.
- The form submits via `use:enhance`, so validation errors keep the drawer open and show the message; the button shows a "Creating…" state while submitting.

## Why

Previously a brand-new batch was created with an empty `devUrl` and the user was dropped on an empty batch page to fill it in. The dashboard list filters out batches with an empty `devUrl` (`devUrl <> ''`), so abandoning that flow left invisible orphan batches. Collecting the URL up front means every created batch is real and appears in the list.

## How to test

1. From the dashboard, click **New batch** — a drawer slides in from the right.
2. Submit with an empty or invalid URL — an inline validation error appears and the drawer stays open.
3. Enter a valid URL (e.g. `https://www.example.test`) and click **Create batch** — the batch is created with that Dev URL and you land on the batch detail page.
4. Confirm the new batch appears in the dashboard list.