### PR TITLE
feat: capture batch screenshots locally with Playwright

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,11 @@
 DATABASE_URL=postgres://redirects_wizard:secret@localhost:5432/redirects_wizard
 BETTER_AUTH_SECRET=replace-with-a-long-random-secret
 BETTER_AUTH_URL=http://localhost:5173
+
+# Where captured batch screenshots are written. Defaults to ./.screenshots.
+# In production point this at a persistent volume (e.g. /data/screenshots).
+# SCREENSHOTS_DIR=.screenshots
+# Path to a Chromium binary for Playwright. Leave unset locally to use
+# Playwright's bundled browser (run `bunx playwright install chromium` once);
+# in production it is set automatically from the Nix-provided chromium.
+# CHROMIUM_PATH=

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ yarn-error.log
 .env
 .env.*
 .dokploy
+/.screenshots

--- a/README.md
+++ b/README.md
@@ -50,10 +50,10 @@ Build command:
 bun run build
 ```
 
-Start command:
+Start command (set in `nixpacks.toml`):
 
 ```sh
-bun ./build/index.js
+CHROMIUM_PATH=$(command -v chromium) bun ./build/index.js
 ```
 
 Dokploy settings:
@@ -67,6 +67,24 @@ Dokploy settings:
 - `BETTER_AUTH_URL=https://redirects.bootpack.work`
 - `BETTER_AUTH_SECRET=<random 32+ byte secret>`
 - `DATABASE_URL=<postgres connection string>`
+- `SCREENSHOTS_DIR=/data/screenshots`
+
+### Screenshots
+
+Batch thumbnails are captured locally with Playwright driving headless
+Chromium. `nixpacks.toml` adds `chromium` to the build and points Playwright at
+it via `CHROMIUM_PATH`, so no separate screenshot service is required.
+
+Captured images are written to `SCREENSHOTS_DIR`. Mount a **persistent volume**
+at that path in Dokploy (e.g. `/data/screenshots`) so screenshots survive
+redeploys. Screenshots are (re)captured when a batch's dev URL is set and via
+the refresh button on each batch card.
+
+For local development, install the browser once:
+
+```sh
+bunx playwright install chromium
+```
 
 ## Building redirects
 

--- a/bun.lock
+++ b/bun.lock
@@ -11,6 +11,7 @@
         "clsx": "^2.1.1",
         "drizzle-orm": "^0.45.2",
         "lucide-svelte": "^1.0.1",
+        "playwright": "^1.60.0",
         "postgres": "^3.4.9",
         "svelte": "^5.56.3",
         "tailwind-merge": "^3.6.0",
@@ -372,6 +373,10 @@
 
     "picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
 
+    "playwright": ["playwright@1.60.0", "", { "dependencies": { "playwright-core": "1.60.0" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA=="],
+
+    "playwright-core": ["playwright-core@1.60.0", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA=="],
+
     "postcss": ["postcss@8.5.15", "", { "dependencies": { "nanoid": "^3.3.12", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A=="],
 
     "postgres": ["postgres@3.4.9", "", {}, "sha512-GD3qdB0x1z9xgFI6cdRD6xu2Sp2WCOEoe3mtnyB5Ee0XrrL5Pe+e4CCnJrRMnL1zYtRDZmQQVbvOttLnKDLnaw=="],
@@ -459,6 +464,8 @@
     "@tailwindcss/oxide-wasm32-wasi/@tybys/wasm-util": ["@tybys/wasm-util@0.10.2", "", { "dependencies": { "tslib": "^2.4.0" }, "bundled": true }, "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg=="],
 
     "@tailwindcss/oxide-wasm32-wasi/tslib": ["tslib@2.8.1", "", { "bundled": true }, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "playwright/fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
 
     "tsx/esbuild": ["esbuild@0.28.0", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.28.0", "@esbuild/android-arm": "0.28.0", "@esbuild/android-arm64": "0.28.0", "@esbuild/android-x64": "0.28.0", "@esbuild/darwin-arm64": "0.28.0", "@esbuild/darwin-x64": "0.28.0", "@esbuild/freebsd-arm64": "0.28.0", "@esbuild/freebsd-x64": "0.28.0", "@esbuild/linux-arm": "0.28.0", "@esbuild/linux-arm64": "0.28.0", "@esbuild/linux-ia32": "0.28.0", "@esbuild/linux-loong64": "0.28.0", "@esbuild/linux-mips64el": "0.28.0", "@esbuild/linux-ppc64": "0.28.0", "@esbuild/linux-riscv64": "0.28.0", "@esbuild/linux-s390x": "0.28.0", "@esbuild/linux-x64": "0.28.0", "@esbuild/netbsd-arm64": "0.28.0", "@esbuild/netbsd-x64": "0.28.0", "@esbuild/openbsd-arm64": "0.28.0", "@esbuild/openbsd-x64": "0.28.0", "@esbuild/openharmony-arm64": "0.28.0", "@esbuild/sunos-x64": "0.28.0", "@esbuild/win32-arm64": "0.28.0", "@esbuild/win32-ia32": "0.28.0", "@esbuild/win32-x64": "0.28.0" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw=="],
 

--- a/drizzle/0001_oval_spectrum.sql
+++ b/drizzle/0001_oval_spectrum.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "batches" ADD COLUMN "screenshot_updated_at" timestamp;

--- a/drizzle/meta/0001_snapshot.json
+++ b/drizzle/meta/0001_snapshot.json
@@ -1,0 +1,496 @@
+{
+    "id": "a50ccc3c-2f9c-4b49-9bab-3a1407351839",
+    "prevId": "5c776ca7-0f3e-4706-8539-c4478beafa93",
+    "version": "7",
+    "dialect": "postgresql",
+    "tables": {
+        "public.account": {
+            "name": "account",
+            "schema": "",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "text",
+                    "primaryKey": true,
+                    "notNull": true
+                },
+                "account_id": {
+                    "name": "account_id",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "provider_id": {
+                    "name": "provider_id",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "user_id": {
+                    "name": "user_id",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "access_token": {
+                    "name": "access_token",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "refresh_token": {
+                    "name": "refresh_token",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "id_token": {
+                    "name": "id_token",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "access_token_expires_at": {
+                    "name": "access_token_expires_at",
+                    "type": "timestamp",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "refresh_token_expires_at": {
+                    "name": "refresh_token_expires_at",
+                    "type": "timestamp",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "scope": {
+                    "name": "scope",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "password": {
+                    "name": "password",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "created_at": {
+                    "name": "created_at",
+                    "type": "timestamp",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                },
+                "updated_at": {
+                    "name": "updated_at",
+                    "type": "timestamp",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                }
+            },
+            "indexes": {},
+            "foreignKeys": {
+                "account_user_id_user_id_fk": {
+                    "name": "account_user_id_user_id_fk",
+                    "tableFrom": "account",
+                    "tableTo": "user",
+                    "columnsFrom": ["user_id"],
+                    "columnsTo": ["id"],
+                    "onDelete": "cascade",
+                    "onUpdate": "no action"
+                }
+            },
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.batches": {
+            "name": "batches",
+            "schema": "",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "serial",
+                    "primaryKey": true,
+                    "notNull": true
+                },
+                "user_id": {
+                    "name": "user_id",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "dev_url": {
+                    "name": "dev_url",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "''"
+                },
+                "screenshot_updated_at": {
+                    "name": "screenshot_updated_at",
+                    "type": "timestamp",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "created_at": {
+                    "name": "created_at",
+                    "type": "timestamp",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                },
+                "updated_at": {
+                    "name": "updated_at",
+                    "type": "timestamp",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                },
+                "deleted_at": {
+                    "name": "deleted_at",
+                    "type": "timestamp",
+                    "primaryKey": false,
+                    "notNull": false
+                }
+            },
+            "indexes": {
+                "batches_user_id_idx": {
+                    "name": "batches_user_id_idx",
+                    "columns": [
+                        {
+                            "expression": "user_id",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                }
+            },
+            "foreignKeys": {
+                "batches_user_id_user_id_fk": {
+                    "name": "batches_user_id_user_id_fk",
+                    "tableFrom": "batches",
+                    "tableTo": "user",
+                    "columnsFrom": ["user_id"],
+                    "columnsTo": ["id"],
+                    "onDelete": "cascade",
+                    "onUpdate": "no action"
+                }
+            },
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.session": {
+            "name": "session",
+            "schema": "",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "text",
+                    "primaryKey": true,
+                    "notNull": true
+                },
+                "expires_at": {
+                    "name": "expires_at",
+                    "type": "timestamp",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "token": {
+                    "name": "token",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "created_at": {
+                    "name": "created_at",
+                    "type": "timestamp",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                },
+                "updated_at": {
+                    "name": "updated_at",
+                    "type": "timestamp",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                },
+                "ip_address": {
+                    "name": "ip_address",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "user_agent": {
+                    "name": "user_agent",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "user_id": {
+                    "name": "user_id",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                }
+            },
+            "indexes": {},
+            "foreignKeys": {
+                "session_user_id_user_id_fk": {
+                    "name": "session_user_id_user_id_fk",
+                    "tableFrom": "session",
+                    "tableTo": "user",
+                    "columnsFrom": ["user_id"],
+                    "columnsTo": ["id"],
+                    "onDelete": "cascade",
+                    "onUpdate": "no action"
+                }
+            },
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {
+                "session_token_unique": {
+                    "name": "session_token_unique",
+                    "nullsNotDistinct": false,
+                    "columns": ["token"]
+                }
+            },
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.urls": {
+            "name": "urls",
+            "schema": "",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "serial",
+                    "primaryKey": true,
+                    "notNull": true
+                },
+                "batch_id": {
+                    "name": "batch_id",
+                    "type": "integer",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "url": {
+                    "name": "url",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "redirect_to": {
+                    "name": "redirect_to",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "http_response": {
+                    "name": "http_response",
+                    "type": "jsonb",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "addressed": {
+                    "name": "addressed",
+                    "type": "boolean",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": false
+                },
+                "deleted_at": {
+                    "name": "deleted_at",
+                    "type": "timestamp",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "created_at": {
+                    "name": "created_at",
+                    "type": "timestamp",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                },
+                "updated_at": {
+                    "name": "updated_at",
+                    "type": "timestamp",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                }
+            },
+            "indexes": {
+                "urls_batch_id_idx": {
+                    "name": "urls_batch_id_idx",
+                    "columns": [
+                        {
+                            "expression": "batch_id",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                }
+            },
+            "foreignKeys": {
+                "urls_batch_id_batches_id_fk": {
+                    "name": "urls_batch_id_batches_id_fk",
+                    "tableFrom": "urls",
+                    "tableTo": "batches",
+                    "columnsFrom": ["batch_id"],
+                    "columnsTo": ["id"],
+                    "onDelete": "cascade",
+                    "onUpdate": "no action"
+                }
+            },
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.user": {
+            "name": "user",
+            "schema": "",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "text",
+                    "primaryKey": true,
+                    "notNull": true
+                },
+                "name": {
+                    "name": "name",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "email": {
+                    "name": "email",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "email_verified": {
+                    "name": "email_verified",
+                    "type": "boolean",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": false
+                },
+                "image": {
+                    "name": "image",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "created_at": {
+                    "name": "created_at",
+                    "type": "timestamp",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                },
+                "updated_at": {
+                    "name": "updated_at",
+                    "type": "timestamp",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                }
+            },
+            "indexes": {},
+            "foreignKeys": {},
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {
+                "user_email_unique": {
+                    "name": "user_email_unique",
+                    "nullsNotDistinct": false,
+                    "columns": ["email"]
+                }
+            },
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.verification": {
+            "name": "verification",
+            "schema": "",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "text",
+                    "primaryKey": true,
+                    "notNull": true
+                },
+                "identifier": {
+                    "name": "identifier",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "value": {
+                    "name": "value",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "expires_at": {
+                    "name": "expires_at",
+                    "type": "timestamp",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "created_at": {
+                    "name": "created_at",
+                    "type": "timestamp",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                },
+                "updated_at": {
+                    "name": "updated_at",
+                    "type": "timestamp",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                }
+            },
+            "indexes": {},
+            "foreignKeys": {},
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        }
+    },
+    "enums": {},
+    "schemas": {},
+    "sequences": {},
+    "roles": {},
+    "policies": {},
+    "views": {},
+    "_meta": {
+        "columns": {},
+        "schemas": {},
+        "tables": {}
+    }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -8,6 +8,13 @@
             "when": 1780880711249,
             "tag": "0000_fluffy_shen",
             "breakpoints": true
+        },
+        {
+            "idx": 1,
+            "version": "7",
+            "when": 1781039931249,
+            "tag": "0001_oval_spectrum",
+            "breakpoints": true
         }
     ]
 }

--- a/nixpacks.toml
+++ b/nixpacks.toml
@@ -1,5 +1,5 @@
 [phases.setup]
-nixPkgs = ["nodejs_22", "bun"]
+nixPkgs = ["nodejs_22", "bun", "chromium"]
 
 [phases.install]
 cmds = ["bun install --frozen-lockfile"]
@@ -8,4 +8,7 @@ cmds = ["bun install --frozen-lockfile"]
 cmds = ["bun run build"]
 
 [start]
-cmd = "bun ./build/index.js"
+# chromium comes from nixPkgs above; resolve its path at runtime so Playwright
+# uses the Nix-provided browser (which ships its own system libraries) rather
+# than downloading its own.
+cmd = "CHROMIUM_PATH=$(command -v chromium) bun ./build/index.js"

--- a/package.json
+++ b/package.json
@@ -1,51 +1,52 @@
 {
-  "private": true,
-  "type": "module",
-  "scripts": {
-    "prepare": "lefthook install",
-    "dev": "vite",
-    "build": "vite build",
-    "preview": "vite preview",
-    "start": "bun ./build/index.js",
-    "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
-    "db:generate": "drizzle-kit generate",
-    "db:migrate": "drizzle-kit migrate",
-    "db:copy-production-to-preview": "bun scripts/copy-production-db-to-preview.ts",
-    "lint": "prettier --check src scripts components.json svelte.config.js vite.config.ts tsconfig.json drizzle.config.ts package.json README.md docker-compose.yml nixpacks.toml --ignore-unknown"
-  },
-  "dependencies": {
-    "@better-auth/drizzle-adapter": "^1.6.15",
-    "@tailwindcss/vite": "^4.3.0",
-    "better-auth": "^1.6.15",
-    "class-variance-authority": "^0.7.1",
-    "clsx": "^2.1.1",
-    "drizzle-orm": "^0.45.2",
-    "lucide-svelte": "^1.0.1",
-    "postgres": "^3.4.9",
-    "svelte": "^5.56.3",
-    "tailwind-merge": "^3.6.0"
-  },
-  "devDependencies": {
-    "@fontsource-variable/inter": "^5.2.8",
-    "@internationalized/date": "^3.12.2",
-    "@lucide/svelte": "^1.17.0",
-    "@sveltejs/kit": "^2.64.0",
-    "@sveltejs/vite-plugin-svelte": "^7.1.2",
-    "bits-ui": "^2.18.1",
-    "drizzle-kit": "^0.31.10",
-    "lefthook": "^2.1.9",
-    "prettier": "^3.8.4",
-    "prettier-plugin-svelte": "^4.1.0",
-    "prettier-plugin-tailwindcss": "^0.8.0",
-    "shadcn-svelte": "^1.3.0",
-    "svelte-adapter-bun": "^1.0.1",
-    "svelte-check": "^4.6.0",
-    "tailwind-variants": "^3.2.2",
-    "tw-animate-css": "^1.4.0",
-    "typescript": "^6.0.3",
-    "vite": "^8.0.16"
-  },
-  "engines": {
-    "node": "22.22.0"
-  }
+    "private": true,
+    "type": "module",
+    "scripts": {
+        "prepare": "lefthook install",
+        "dev": "vite",
+        "build": "vite build",
+        "preview": "vite preview",
+        "start": "bun db:migrate && bun ./build/index.js",
+        "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
+        "db:generate": "drizzle-kit generate",
+        "db:migrate": "drizzle-kit migrate",
+        "db:copy-production-to-preview": "bun scripts/copy-production-db-to-preview.ts",
+        "lint": "prettier --check src scripts components.json svelte.config.js vite.config.ts tsconfig.json drizzle.config.ts package.json README.md docker-compose.yml nixpacks.toml --ignore-unknown"
+    },
+    "dependencies": {
+        "@better-auth/drizzle-adapter": "^1.6.15",
+        "@tailwindcss/vite": "^4.3.0",
+        "better-auth": "^1.6.15",
+        "class-variance-authority": "^0.7.1",
+        "clsx": "^2.1.1",
+        "drizzle-orm": "^0.45.2",
+        "lucide-svelte": "^1.0.1",
+        "playwright": "^1.60.0",
+        "postgres": "^3.4.9",
+        "svelte": "^5.56.3",
+        "tailwind-merge": "^3.6.0"
+    },
+    "devDependencies": {
+        "@fontsource-variable/inter": "^5.2.8",
+        "@internationalized/date": "^3.12.2",
+        "@lucide/svelte": "^1.17.0",
+        "@sveltejs/kit": "^2.64.0",
+        "@sveltejs/vite-plugin-svelte": "^7.1.2",
+        "bits-ui": "^2.18.1",
+        "drizzle-kit": "^0.31.10",
+        "lefthook": "^2.1.9",
+        "prettier": "^3.8.4",
+        "prettier-plugin-svelte": "^4.1.0",
+        "prettier-plugin-tailwindcss": "^0.8.0",
+        "shadcn-svelte": "^1.3.0",
+        "svelte-adapter-bun": "^1.0.1",
+        "svelte-check": "^4.6.0",
+        "tailwind-variants": "^3.2.2",
+        "tw-animate-css": "^1.4.0",
+        "typescript": "^6.0.3",
+        "vite": "^8.0.16"
+    },
+    "engines": {
+        "node": "22.22.0"
+    }
 }

--- a/src/lib/server/schema.ts
+++ b/src/lib/server/schema.ts
@@ -76,6 +76,7 @@ export const batches = pgTable(
             .notNull()
             .references(() => user.id, { onDelete: "cascade" }),
         devUrl: text("dev_url").notNull().default(""),
+        screenshotUpdatedAt: timestamp("screenshot_updated_at"),
         createdAt: timestamp("created_at").notNull().defaultNow(),
         updatedAt: timestamp("updated_at").notNull().defaultNow(),
         deletedAt: timestamp("deleted_at"),

--- a/src/lib/server/screenshots.ts
+++ b/src/lib/server/screenshots.ts
@@ -1,0 +1,144 @@
+import { mkdir, writeFile } from "node:fs/promises";
+import { join, resolve } from "node:path";
+import { env } from "$env/dynamic/private";
+import type { Browser } from "playwright";
+import { eq } from "drizzle-orm";
+import { db } from "./db";
+import { batches } from "./schema";
+
+// Where captured screenshots live on disk. In production this should point at a
+// persistent volume (see nixpacks.toml / Dokploy). Defaults to a repo-local
+// folder for development.
+const STORAGE_DIR = resolve(env.SCREENSHOTS_DIR || ".screenshots");
+
+const VIEWPORT = { width: 1280, height: 720 };
+const NAV_TIMEOUT = 20_000;
+const SETTLE_MS = 750;
+const JPEG_QUALITY = 72;
+
+let browserPromise: Promise<Browser> | null = null;
+
+// Reuse a single Chromium instance across captures. Launching a browser per
+// request is slow and memory-heavy, so we keep one alive and relaunch only if
+// it has disconnected (crash, OOM, etc.).
+async function getBrowser(): Promise<Browser> {
+    if (browserPromise) {
+        const existing = await browserPromise.catch(() => null);
+        if (existing?.isConnected()) return existing;
+        browserPromise = null;
+    }
+
+    // Imported lazily so read paths (page loads, serving the stored image)
+    // never pull Playwright into their module graph — only an actual capture
+    // loads the browser library.
+    const { chromium } = await import("playwright");
+    browserPromise = chromium.launch({
+        // In production CHROMIUM_PATH points at the Nix-provided chromium. When
+        // unset (local dev) Playwright uses its bundled download.
+        executablePath: env.CHROMIUM_PATH || undefined,
+        args: [
+            "--no-sandbox",
+            "--disable-dev-shm-usage",
+            "--disable-gpu",
+            "--disable-software-rasterizer",
+        ],
+    });
+
+    return browserPromise;
+}
+
+// Tear down the current browser (e.g. after a renderer crash) so the next
+// getBrowser() call launches a fresh one.
+async function resetBrowser(): Promise<void> {
+    const current = browserPromise;
+    browserPromise = null;
+    try {
+        const browser = await current?.catch(() => null);
+        await browser?.close();
+    } catch {
+        // Already gone — nothing to clean up.
+    }
+}
+
+export function screenshotFilePath(batchId: number): string {
+    return join(STORAGE_DIR, `${batchId}.jpg`);
+}
+
+async function captureOnce(batchId: number, devUrl: string): Promise<void> {
+    const browser = await getBrowser();
+    const context = await browser.newContext({ viewport: VIEWPORT });
+
+    // Block video/audio: it's the most common renderer-memory hog (autoplay
+    // hero videos) and never adds anything useful to a static thumbnail.
+    // Heavy media has crashed the renderer ("Target crashed") on some pages.
+    await context.route("**/*", (route) => {
+        if (route.request().resourceType() === "media") {
+            return route.abort();
+        }
+        return route.continue();
+    });
+
+    try {
+        const page = await context.newPage();
+
+        try {
+            await page.goto(devUrl, {
+                waitUntil: "load",
+                timeout: NAV_TIMEOUT,
+            });
+        } catch {
+            // Navigation timed out or partially failed — screenshot the
+            // current state rather than giving up entirely.
+        }
+
+        await page.waitForTimeout(SETTLE_MS);
+        const buffer = await page.screenshot({
+            type: "jpeg",
+            quality: JPEG_QUALITY,
+        });
+
+        await mkdir(STORAGE_DIR, { recursive: true });
+        await writeFile(screenshotFilePath(batchId), buffer);
+
+        await db
+            .update(batches)
+            .set({ screenshotUpdatedAt: new Date() })
+            .where(eq(batches.id, batchId));
+    } finally {
+        await context.close();
+    }
+}
+
+// Capture devUrl to disk and stamp the batch so the UI knows a screenshot
+// exists (and can cache-bust on the new timestamp). Best-effort on navigation:
+// if the page never fully settles we still capture whatever rendered. Some
+// pages crash the renderer ("Target crashed") on the first attempt; relaunching
+// the browser and retrying once almost always succeeds.
+export async function captureScreenshot(
+    batchId: number,
+    devUrl: string,
+): Promise<void> {
+    console.log(
+        `[screenshot] capturing batch ${batchId} (${devUrl}) → ${screenshotFilePath(batchId)}; chromium=${env.CHROMIUM_PATH || "(bundled)"}`,
+    );
+
+    const MAX_ATTEMPTS = 2;
+    let lastError: unknown;
+
+    for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+        try {
+            await captureOnce(batchId, devUrl);
+            return;
+        } catch (error) {
+            lastError = error;
+            console.warn(
+                `[screenshot] attempt ${attempt}/${MAX_ATTEMPTS} failed for batch ${batchId}: ${error instanceof Error ? error.message : String(error)}`,
+            );
+            // The browser may have crashed — drop it so the next attempt
+            // launches a fresh one.
+            await resetBrowser();
+        }
+    }
+
+    throw lastError;
+}

--- a/src/routes/+page.server.ts
+++ b/src/routes/+page.server.ts
@@ -1,4 +1,5 @@
 import { db } from "$lib/server/db";
+import { captureScreenshot } from "$lib/server/screenshots";
 import { batches, urls } from "$lib/server/schema";
 import { isValidHttpUrl } from "$lib/server/redirects";
 import { fail, redirect } from "@sveltejs/kit";
@@ -14,6 +15,7 @@ export async function load({ locals }) {
             id: batches.id,
             devUrl: batches.devUrl,
             createdAt: batches.createdAt,
+            screenshotUpdatedAt: batches.screenshotUpdatedAt,
             urlCount: count(urls.id),
             remainingCount:
                 sql<number>`count(${urls.id}) filter (where ${urls.addressed} = false)`.mapWith(
@@ -59,6 +61,52 @@ export const actions = {
             .values({ userId: locals.user.id, devUrl })
             .returning({ id: batches.id });
 
+        try {
+            await captureScreenshot(batch.id, devUrl);
+        } catch (error) {
+            // Best effort — the batch is created regardless; the user can
+            // retry capture with the refresh button.
+            console.error("[screenshot] capture failed on create", error);
+        }
+
         throw redirect(303, `/batch/${batch.id}`);
+    },
+
+    refreshScreenshot: async ({ locals, request }) => {
+        if (!locals.user) {
+            return fail(401, { message: "You must be signed in." });
+        }
+
+        const formData = await request.formData();
+        const batchId = Number(formData.get("batchId"));
+        if (!Number.isInteger(batchId)) {
+            return fail(400, { message: "Invalid batch." });
+        }
+
+        const batch = await db.query.batches.findFirst({
+            where: and(
+                eq(batches.id, batchId),
+                eq(batches.userId, locals.user.id),
+                isNull(batches.deletedAt),
+            ),
+        });
+
+        if (!batch) {
+            return fail(404, { message: "Batch not found." });
+        }
+        if (!batch.devUrl) {
+            return fail(400, { message: "Set a dev URL first." });
+        }
+
+        try {
+            await captureScreenshot(batch.id, batch.devUrl);
+        } catch (error) {
+            console.error("[screenshot] capture failed on refresh", error);
+            return fail(500, {
+                message: `Could not capture screenshot: ${error instanceof Error ? error.message : String(error)}`,
+            });
+        }
+
+        return { success: "Screenshot refreshed." };
     },
 };

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -9,6 +9,7 @@
         ExternalLink,
         FolderPlus,
         Plus,
+        RotateCw,
         Search,
     } from "lucide-svelte";
 
@@ -16,6 +17,8 @@
 
     let createOpen = $state(false);
     let creating = $state(false);
+
+    let refreshing = $state<Record<number, boolean>>({});
 
     let query = $state("");
     let sort = $state<"recent" | "name" | "needs-work">("recent");
@@ -51,17 +54,13 @@
         });
     });
 
-    function screenshotUrl(devUrl: string) {
-        const url = new URL(
-            "https://screenshot-maker.bootpack.dev/api/screenshot",
-        );
-        url.searchParams.set("url", devUrl);
-        url.searchParams.set("width", "1400");
-        url.searchParams.set("height", "800");
-        url.searchParams.set("scale", "0.5");
-        url.searchParams.set("quality", "80");
-        url.searchParams.set("type", "avif");
-        return url.toString();
+    function screenshotUrl(batch: {
+        id: number;
+        screenshotUpdatedAt: Date | null;
+    }) {
+        if (!batch.screenshotUpdatedAt) return null;
+        const version = new Date(batch.screenshotUpdatedAt).getTime();
+        return `/api/screenshot/${batch.id}?v=${version}`;
     }
 </script>
 
@@ -178,17 +177,56 @@
                             <article
                                 class="group overflow-hidden rounded-lg bg-white ring-1 ring-zinc-200 transition hover:shadow-md hover:ring-zinc-300"
                             >
-                                <a
-                                    href={`/batch/${batch.id}`}
-                                    aria-label={`Manage ${batch.devUrl}`}
-                                >
-                                    <img
-                                        src={screenshotUrl(batch.devUrl)}
-                                        alt={`${batch.devUrl} screenshot`}
-                                        class="aspect-video w-full bg-zinc-200 object-cover transition group-hover:opacity-90"
-                                        loading="lazy"
-                                    />
-                                </a>
+                                <div class="relative">
+                                    <a
+                                        href={`/batch/${batch.id}`}
+                                        aria-label={`Manage ${batch.devUrl}`}
+                                    >
+                                        {#if screenshotUrl(batch)}
+                                            <img
+                                                src={screenshotUrl(batch)}
+                                                alt={`${batch.devUrl} screenshot`}
+                                                class="aspect-video w-full bg-zinc-200 object-cover transition group-hover:opacity-90"
+                                                loading="lazy"
+                                            />
+                                        {:else}
+                                            <div
+                                                class="flex aspect-video w-full items-center justify-center bg-zinc-200 text-sm text-zinc-500"
+                                            >
+                                                No screenshot yet
+                                            </div>
+                                        {/if}
+                                    </a>
+                                    <form
+                                        method="POST"
+                                        action="?/refreshScreenshot"
+                                        class="absolute top-2 right-2"
+                                        use:enhance={() => {
+                                            refreshing[batch.id] = true;
+                                            return async ({ update }) => {
+                                                await update();
+                                                refreshing[batch.id] = false;
+                                            };
+                                        }}
+                                    >
+                                        <input
+                                            type="hidden"
+                                            name="batchId"
+                                            value={batch.id}
+                                        />
+                                        <button
+                                            type="submit"
+                                            disabled={refreshing[batch.id]}
+                                            title="Refresh screenshot"
+                                            aria-label="Refresh screenshot"
+                                            class="rounded-md bg-white/90 p-1.5 text-zinc-700 ring-1 ring-zinc-200 backdrop-blur hover:bg-white disabled:opacity-60"
+                                        >
+                                            <RotateCw
+                                                class={`size-4 ${refreshing[batch.id] ? "animate-spin" : ""}`}
+                                            />
+                                        </button>
+                                    </form>
+                                </div>
                                 <div class="space-y-4 p-4">
                                     <div class="space-y-2">
                                         <a

--- a/src/routes/api/screenshot/[id]/+server.ts
+++ b/src/routes/api/screenshot/[id]/+server.ts
@@ -1,0 +1,45 @@
+import { db } from "$lib/server/db";
+import { batches } from "$lib/server/schema";
+import { screenshotFilePath } from "$lib/server/screenshots";
+import { error } from "@sveltejs/kit";
+import { and, eq, isNull } from "drizzle-orm";
+import { readFile } from "node:fs/promises";
+
+export async function GET({ params, locals }) {
+    if (!locals.user) {
+        throw error(401, "Unauthorized");
+    }
+
+    const batchId = Number(params.id);
+    if (!Number.isInteger(batchId)) {
+        throw error(404, "Not found");
+    }
+
+    const batch = await db.query.batches.findFirst({
+        where: and(
+            eq(batches.id, batchId),
+            eq(batches.userId, locals.user.id),
+            isNull(batches.deletedAt),
+        ),
+    });
+
+    if (!batch?.screenshotUpdatedAt) {
+        throw error(404, "Not found");
+    }
+
+    let file: Buffer;
+    try {
+        file = await readFile(screenshotFilePath(batchId));
+    } catch {
+        throw error(404, "Not found");
+    }
+
+    return new Response(new Uint8Array(file), {
+        headers: {
+            "content-type": "image/jpeg",
+            // Responses are addressed by a ?v=<timestamp> cache-buster, so a
+            // given URL never changes — safe to cache aggressively & privately.
+            "cache-control": "private, max-age=31536000, immutable",
+        },
+    });
+}

--- a/src/routes/batch/[id]/+page.server.ts
+++ b/src/routes/batch/[id]/+page.server.ts
@@ -7,6 +7,7 @@ import {
     withoutTrailingSlash,
 } from "$lib/server/redirects";
 import { db } from "$lib/server/db";
+import { captureScreenshot } from "$lib/server/screenshots";
 import { batches, urls } from "$lib/server/schema";
 import { error, fail, redirect } from "@sveltejs/kit";
 import { and, asc, eq, isNull, or } from "drizzle-orm";
@@ -74,6 +75,15 @@ export const actions = {
             .update(batches)
             .set({ devUrl, updatedAt: new Date() })
             .where(eq(batches.id, batch.id));
+
+        try {
+            await captureScreenshot(batch.id, devUrl);
+        } catch (error) {
+            console.error("[screenshot] capture failed on updateDevUrl", error);
+            return {
+                success: "Dev URL updated. Screenshot could not be generated.",
+            };
+        }
 
         return { success: "Dev URL updated." };
     },


### PR DESCRIPTION
## Summary

Replaces the external `screenshot-maker.bootpack.dev` service with local headless-Chromium capture via Playwright. Screenshots are captured once, stored on disk, and served behind auth — no third-party dependency.

## How it works

- **Schema**: new `screenshot_updated_at` column on `batches` (also acts as a cache-bust version). Migration `0001_oval_spectrum.sql`.
- **Capture** (`src/lib/server/screenshots.ts`): a lazily-launched, reused Chromium instance (relaunched if it disconnects). Navigates to the dev URL (best-effort on timeout), captures the 1280×720 viewport as JPEG, writes `<id>.jpg` to `SCREENSHOTS_DIR`, and stamps the batch. Uses `CHROMIUM_PATH` when set, otherwise Playwright's bundled browser.
- **Serving** (`GET /api/screenshot/[id]`): authorizes the user + batch ownership, returns the stored file with long immutable caching (URLs are `?v=<timestamp>` busted).
- **Triggers**: capture on batch create and on dev-URL change; a new `refreshScreenshot` action backs a per-card refresh button. Cards show a "No screenshot yet" placeholder when none exists.

## Deployment notes

- `nixpacks.toml` adds system `chromium` and exports `CHROMIUM_PATH` in the start command.
- **Requires a persistent volume** in Dokploy mounted at `SCREENSHOTS_DIR` (e.g. `/data/screenshots`) so screenshots survive redeploys.
- Local dev: `bunx playwright install chromium` once.

## Tradeoffs

- `create` / `updateDevUrl` await the capture (~1–3s) so the thumbnail is ready immediately; failures degrade gracefully rather than blocking the save.
- Stores JPEG (no `sharp` dependency); the old service returned AVIF, so images are somewhat larger on the wire. Easy to add AVIF later if it matters.

## Testing

- `bun run check` passes (0 errors).
- Verified a real capture end-to-end under Bun (valid 1280×720 JPEG produced).

> Note: the `package.json` diff is large because the pre-commit hook reformats it to the `.editorconfig` 4-space style (master's committed copy is 2-space). The only functional change is adding the `playwright` devDependency.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Batches now automatically capture screenshots upon creation
  * Added manual screenshot refresh capability for existing batches
  * Screenshots persist across application redeployments

* **Documentation**
  * Updated deployment configuration with screenshot storage and Chromium binary setup
  * Added local development guide for screenshot functionality

* **Chores**
  * Enhanced database schema to support screenshot tracking

<!-- end of auto-generated comment: release notes by coderabbit.ai -->