### PR TITLE
Fix batch sorting and switch tooling to Vite+

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install Bun
         uses: oven-sh/setup-bun@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,32 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Install Vite+
+        env:
+          VP_VERSION: 0.1.24
+          VP_NODE_MANAGER: "no"
+        run: |
+          curl -fsSL https://viteplus.dev/install.sh | bash
+          echo "$HOME/.vite-plus/bin" >> "$GITHUB_PATH"
+
+      - name: Check formatting
+        run: vp fmt --check
+
+      - name: Lint
+        run: vp lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,12 +18,10 @@ jobs:
         run: bun install --frozen-lockfile
 
       - name: Install Vite+
-        env:
-          VP_VERSION: 0.1.24
-          VP_NODE_MANAGER: "no"
-        run: |
-          curl -fsSL https://viteplus.dev/install.sh | bash
-          echo "$HOME/.vite-plus/bin" >> "$GITHUB_PATH"
+        uses: voidzero-dev/setup-vp@v1
+        with:
+          version: 0.1.24
+          run-install: false
 
       - name: Check formatting
         run: vp fmt --check

--- a/bun.lock
+++ b/bun.lock
@@ -25,9 +25,6 @@
         "bits-ui": "^2.18.1",
         "drizzle-kit": "^0.31.10",
         "lefthook": "^2.1.9",
-        "prettier": "^3.8.4",
-        "prettier-plugin-svelte": "^4.1.0",
-        "prettier-plugin-tailwindcss": "^0.8.0",
         "shadcn-svelte": "^1.3.0",
         "svelte-adapter-bun": "^1.0.1",
         "svelte-check": "^4.6.0",
@@ -380,12 +377,6 @@
     "postcss": ["postcss@8.5.15", "", { "dependencies": { "nanoid": "^3.3.12", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A=="],
 
     "postgres": ["postgres@3.4.9", "", {}, "sha512-GD3qdB0x1z9xgFI6cdRD6xu2Sp2WCOEoe3mtnyB5Ee0XrrL5Pe+e4CCnJrRMnL1zYtRDZmQQVbvOttLnKDLnaw=="],
-
-    "prettier": ["prettier@3.8.4", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-N2MylSdi48+5N/6S5j+maeHbUSIzzZ5uOcX5Hm4QpV8Dkb1HFjfAKTKX6yNPJQD9AhcT3ifHNB66tWTTJDi11Q=="],
-
-    "prettier-plugin-svelte": ["prettier-plugin-svelte@4.1.0", "", { "peerDependencies": { "prettier": "^3.0.0", "svelte": "^5.0.0" } }, "sha512-YZkhA2Q9oOerFFG9tq+2f98WYT7Z2JgrybJrAyrB78jpsH9i/DdgplXemehuFPgsldetFNCcR/yCcYlDjPy94Q=="],
-
-    "prettier-plugin-tailwindcss": ["prettier-plugin-tailwindcss@0.8.0", "", { "peerDependencies": { "@ianvs/prettier-plugin-sort-imports": "*", "@prettier/plugin-hermes": "*", "@prettier/plugin-oxc": "*", "@prettier/plugin-pug": "*", "@shopify/prettier-plugin-liquid": "*", "@trivago/prettier-plugin-sort-imports": "*", "@zackad/prettier-plugin-twig": "*", "prettier": "^3.0", "prettier-plugin-astro": "*", "prettier-plugin-css-order": "*", "prettier-plugin-jsdoc": "*", "prettier-plugin-marko": "*", "prettier-plugin-multiline-arrays": "*", "prettier-plugin-organize-attributes": "*", "prettier-plugin-organize-imports": "*", "prettier-plugin-sort-imports": "*", "prettier-plugin-svelte": "*" }, "optionalPeers": ["@ianvs/prettier-plugin-sort-imports", "@prettier/plugin-hermes", "@prettier/plugin-oxc", "@prettier/plugin-pug", "@shopify/prettier-plugin-liquid", "@trivago/prettier-plugin-sort-imports", "@zackad/prettier-plugin-twig", "prettier-plugin-astro", "prettier-plugin-css-order", "prettier-plugin-jsdoc", "prettier-plugin-marko", "prettier-plugin-multiline-arrays", "prettier-plugin-organize-attributes", "prettier-plugin-organize-imports", "prettier-plugin-sort-imports", "prettier-plugin-svelte"] }, "sha512-V8ITGH87yuBDF6JpEZTOVlUz/saAwqb8f3HRgUj8Lh+tGCcrmorhsLpYqzygwFwK0PE2Ib6Mv3M7T/uE2tZV1g=="],
 
     "readdirp": ["readdirp@4.1.2", "", {}, "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg=="],
 

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -3,5 +3,10 @@ pre-commit:
   jobs:
     - name: oxfmt
       glob: "{*,**/*}.{ts,js,mjs,cjs}"
-      run: vp fmt --write {staged_files}
+      run: |
+        command -v vp >/dev/null 2>&1 || {
+          echo "vp (Vite+) not found. Install it from https://viteplus.dev"
+          exit 1
+        }
+        vp fmt --write {staged_files}
       stage_fixed: true

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,7 +1,7 @@
 pre-commit:
   parallel: true
   jobs:
-    - name: prettier
-      glob: "{*,**/*}.{svelte,ts,js,css,json,md,yml,yaml}"
-      run: bunx prettier --write --ignore-unknown {staged_files}
+    - name: oxfmt
+      glob: "{*,**/*}.{ts,js,mjs,cjs}"
+      run: vp fmt --write {staged_files}
       stage_fixed: true

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
         "db:generate": "drizzle-kit generate",
         "db:migrate": "drizzle-kit migrate",
         "db:copy-production-to-preview": "bun scripts/copy-production-db-to-preview.ts",
-        "lint": "prettier --check src scripts components.json svelte.config.js vite.config.ts tsconfig.json drizzle.config.ts package.json README.md docker-compose.yml nixpacks.toml --ignore-unknown"
+        "format": "vp fmt --write",
+        "lint": "vp fmt --check && vp lint"
     },
     "dependencies": {
         "@better-auth/drizzle-adapter": "^1.6.15",
@@ -35,9 +36,6 @@
         "bits-ui": "^2.18.1",
         "drizzle-kit": "^0.31.10",
         "lefthook": "^2.1.9",
-        "prettier": "^3.8.4",
-        "prettier-plugin-svelte": "^4.1.0",
-        "prettier-plugin-tailwindcss": "^0.8.0",
         "shadcn-svelte": "^1.3.0",
         "svelte-adapter-bun": "^1.0.1",
         "svelte-check": "^4.6.0",

--- a/scripts/copy-production-db-to-preview.ts
+++ b/scripts/copy-production-db-to-preview.ts
@@ -18,10 +18,7 @@ const defaultEnvFile = ".env";
 const envFile = resolve(
     process.cwd(),
     process.argv.find(
-        (arg) =>
-            !arg.startsWith("--") &&
-            arg !== process.argv[0] &&
-            arg !== process.argv[1],
+        (arg) => !arg.startsWith("--") && arg !== process.argv[0] && arg !== process.argv[1],
     ) ?? defaultEnvFile,
 );
 
@@ -42,9 +39,7 @@ if (!previewDatabaseUrl) {
 }
 
 if (productionDatabaseUrl === previewDatabaseUrl) {
-    throw new Error(
-        "PRODUCTION_DATABASE_URL and PREVIEW_DATABASE_URL must be different.",
-    );
+    throw new Error("PRODUCTION_DATABASE_URL and PREVIEW_DATABASE_URL must be different.");
 }
 
 const production = parsePostgresConnection(productionDatabaseUrl);
@@ -56,14 +51,7 @@ try {
     console.log(`Dumping production database: ${production.redactedUrl}`);
     run(
         "pg_dump",
-        [
-            "--format=custom",
-            "--no-owner",
-            "--no-acl",
-            "--file",
-            dumpFile,
-            production.database,
-        ],
+        ["--format=custom", "--no-owner", "--no-acl", "--file", dumpFile, production.database],
         production.env,
     );
 
@@ -103,10 +91,7 @@ function parseEnvFile(contents: string) {
 }
 
 function parseEnvLine(line: string): EnvLine | undefined {
-    const match =
-        /^(?:\s*export\s+)?(?<key>[A-Za-z_][A-Za-z0-9_]*)\s*=\s*(?<raw>.*)$/.exec(
-            line,
-        );
+    const match = /^(?:\s*export\s+)?(?<key>[A-Za-z_][A-Za-z0-9_]*)\s*=\s*(?<raw>.*)$/.exec(line);
 
     if (!match?.groups) return undefined;
 
@@ -250,30 +235,15 @@ function parsePostgresConnection(databaseUrl: string): PostgresConnection {
     if (url.password) env.PGPASSWORD = decodeURIComponent(url.password);
 
     setOptionalLibpqEnv(env, url.searchParams, "application_name", "PGAPPNAME");
-    setOptionalLibpqEnv(
-        env,
-        url.searchParams,
-        "channel_binding",
-        "PGCHANNELBINDING",
-    );
-    setOptionalLibpqEnv(
-        env,
-        url.searchParams,
-        "connect_timeout",
-        "PGCONNECT_TIMEOUT",
-    );
+    setOptionalLibpqEnv(env, url.searchParams, "channel_binding", "PGCHANNELBINDING");
+    setOptionalLibpqEnv(env, url.searchParams, "connect_timeout", "PGCONNECT_TIMEOUT");
     setOptionalLibpqEnv(env, url.searchParams, "options", "PGOPTIONS");
     setOptionalLibpqEnv(env, url.searchParams, "sslcert", "PGSSLCERT");
     setOptionalLibpqEnv(env, url.searchParams, "sslcrl", "PGSSLCRL");
     setOptionalLibpqEnv(env, url.searchParams, "sslkey", "PGSSLKEY");
     setOptionalLibpqEnv(env, url.searchParams, "sslmode", "PGSSLMODE");
     setOptionalLibpqEnv(env, url.searchParams, "sslrootcert", "PGSSLROOTCERT");
-    setOptionalLibpqEnv(
-        env,
-        url.searchParams,
-        "target_session_attrs",
-        "PGTARGETSESSIONATTRS",
-    );
+    setOptionalLibpqEnv(env, url.searchParams, "target_session_attrs", "PGTARGETSESSIONATTRS");
 
     return {
         database,

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -5,10 +5,7 @@ import { betterAuth } from "better-auth";
 import { db } from "$lib/server/db";
 import * as schema from "$lib/server/schema";
 
-function requiredEnv(
-    name: "BETTER_AUTH_SECRET" | "BETTER_AUTH_URL",
-    fallback: string,
-) {
+function requiredEnv(name: "BETTER_AUTH_SECRET" | "BETTER_AUTH_URL", fallback: string) {
     const value = env[name];
     if (!value && !building) {
         throw new Error(`${name} is required.`);
@@ -19,10 +16,7 @@ function requiredEnv(
 
 export const auth = betterAuth({
     baseURL: requiredEnv("BETTER_AUTH_URL", "http://localhost:3000"),
-    secret: requiredEnv(
-        "BETTER_AUTH_SECRET",
-        "build-time-placeholder-secret-with-enough-length",
-    ),
+    secret: requiredEnv("BETTER_AUTH_SECRET", "build-time-placeholder-secret-with-enough-length"),
     database: drizzleAdapter(db, {
         provider: "pg",
         schema,

--- a/src/lib/server/redirects.ts
+++ b/src/lib/server/redirects.ts
@@ -27,9 +27,7 @@ type RedirectRule = {
 export function normalizeUrlInput(url: string) {
     const withoutHash = url.trim().split("#")[0] ?? "";
     if (!withoutHash) return "";
-    return withoutHash.startsWith("http")
-        ? withoutHash
-        : `http://${withoutHash}`;
+    return withoutHash.startsWith("http") ? withoutHash : `http://${withoutHash}`;
 }
 
 export function withoutTrailingSlash(url: string) {
@@ -84,9 +82,7 @@ function normalizeRedirectTarget(batch: BatchLike, url: UrlLike) {
 function getRedirectRule(batch: BatchLike, url: UrlLike): RedirectRule {
     const current = new URL(url.url);
     const target = normalizeRedirectTarget(batch, url);
-    const sourceQuery = current.search.startsWith("?")
-        ? current.search.slice(1)
-        : "";
+    const sourceQuery = current.search.startsWith("?") ? current.search.slice(1) : "";
     const sourcePathWithQuery = `${current.pathname}${current.search}`;
     const targetPathWithQuery = `${target.pathname}${target.search}`;
 
@@ -140,11 +136,7 @@ function getNginxRedirect(batch: BatchLike, url: UrlLike) {
         ].join("\n");
     }
 
-    return [
-        `location = ${rule.sourcePath} {`,
-        `    return 301 ${target};`,
-        "}",
-    ].join("\n");
+    return [`location = ${rule.sourcePath} {`, `    return 301 ${target};`, "}"].join("\n");
 }
 
 function getCaddyRedirect(batch: BatchLike, url: UrlLike, index: number) {
@@ -177,20 +169,15 @@ export function getRedirectFormats(batch: BatchLike, redirectUrls: UrlLike[]) {
         const aRule = getRedirectRule(batch, a);
         const bRule = getRedirectRule(batch, b);
         return (
-            bRule.sourcePathWithQuery.length -
-                aRule.sourcePathWithQuery.length ||
+            bRule.sourcePathWithQuery.length - aRule.sourcePathWithQuery.length ||
             aRule.sourcePathWithQuery.localeCompare(bRule.sourcePathWithQuery)
         );
     });
 
     const apacheRules = sortedUrls.map((url) => getApacheRewrite(batch, url));
     const nginxRules = sortedUrls.map((url) => getNginxRedirect(batch, url));
-    const caddyRules = sortedUrls.map((url, index) =>
-        getCaddyRedirect(batch, url, index),
-    );
-    const netlifyRules = sortedUrls.map((url) =>
-        getNetlifyRedirect(batch, url),
-    );
+    const caddyRules = sortedUrls.map((url, index) => getCaddyRedirect(batch, url, index));
+    const netlifyRules = sortedUrls.map((url) => getNetlifyRedirect(batch, url));
 
     return [
         {

--- a/src/lib/server/redirects.ts
+++ b/src/lib/server/redirects.ts
@@ -27,7 +27,7 @@ type RedirectRule = {
 export function normalizeUrlInput(url: string) {
     const withoutHash = url.trim().split("#")[0] ?? "";
     if (!withoutHash) return "";
-    return withoutHash.startsWith("http") ? withoutHash : `http://${withoutHash}`;
+    return /^https?:\/\//i.test(withoutHash) ? withoutHash : `http://${withoutHash}`;
 }
 
 export function withoutTrailingSlash(url: string) {

--- a/src/lib/server/screenshots.ts
+++ b/src/lib/server/screenshots.ts
@@ -94,8 +94,7 @@ function isBlockedVideoRequest(url: string): boolean {
     }
 
     return BLOCKED_VIDEO_HOSTS.some(
-        (blockedHost) =>
-            hostname === blockedHost || hostname.endsWith(`.${blockedHost}`),
+        (blockedHost) => hostname === blockedHost || hostname.endsWith(`.${blockedHost}`),
     );
 }
 
@@ -146,11 +145,7 @@ async function preparePageForScreenshot(page: Page): Promise<void> {
     });
 }
 
-async function captureOnce(
-    batchId: number,
-    devUrl: string,
-    mode: CaptureMode,
-): Promise<void> {
+async function captureOnce(batchId: number, devUrl: string, mode: CaptureMode): Promise<void> {
     const browser = await getBrowser();
     const context = await browser.newContext({
         viewport: VIEWPORT,
@@ -163,10 +158,7 @@ async function captureOnce(
     // crashed") on some pages, and iframe players can keep load from settling.
     await context.route("**/*", (route) => {
         const request = route.request();
-        if (
-            request.resourceType() === "media" ||
-            isBlockedVideoRequest(request.url())
-        ) {
+        if (request.resourceType() === "media" || isBlockedVideoRequest(request.url())) {
             return route.abort();
         }
         return route.continue();
@@ -213,10 +205,7 @@ async function captureOnce(
 // if the page never fully settles we still capture whatever rendered. Some
 // pages crash the renderer ("Target crashed") with their own scripts running,
 // so the fallback retries as a static document with JavaScript disabled.
-export async function captureScreenshot(
-    batchId: number,
-    devUrl: string,
-): Promise<void> {
+export async function captureScreenshot(batchId: number, devUrl: string): Promise<void> {
     console.log(
         `[screenshot] capturing batch ${batchId} (${devUrl}) → ${screenshotFilePath(batchId)}; chromium=${env.CHROMIUM_PATH || "(bundled)"}`,
     );
@@ -228,9 +217,7 @@ export async function captureScreenshot(
 
         try {
             await captureOnce(batchId, devUrl, mode);
-            console.log(
-                `[screenshot] captured batch ${batchId} using ${mode.name} mode`,
-            );
+            console.log(`[screenshot] captured batch ${batchId} using ${mode.name} mode`);
             return;
         } catch (error) {
             lastError = error;

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -19,9 +19,7 @@ export function urlSortKey(url: string) {
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type WithoutChild<T> = T extends { child?: any } ? Omit<T, "child"> : T;
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export type WithoutChildren<T> = T extends { children?: any }
-    ? Omit<T, "children">
-    : T;
+export type WithoutChildren<T> = T extends { children?: any } ? Omit<T, "children"> : T;
 export type WithoutChildrenOrChild<T> = WithoutChildren<WithoutChild<T>>;
 export type WithElementRef<T, U extends HTMLElement = HTMLElement> = T & {
     ref?: U | null;

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -5,6 +5,17 @@ export function cn(...inputs: ClassValue[]) {
     return twMerge(clsx(inputs));
 }
 
+/**
+ * Returns a sortable key for a URL that ignores the protocol and a leading
+ * "www." so that, e.g., "www.thing.com" sorts before "uuu.com".
+ */
+export function urlSortKey(url: string) {
+    return url
+        .toLowerCase()
+        .replace(/^[a-z][a-z0-9+.-]*:\/\//, "")
+        .replace(/^www\./, "");
+}
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type WithoutChild<T> = T extends { child?: any } ? Omit<T, "child"> : T;
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/routes/+page.server.ts
+++ b/src/routes/+page.server.ts
@@ -23,10 +23,7 @@ export async function load({ locals }) {
                 ),
         })
         .from(batches)
-        .leftJoin(
-            urls,
-            and(eq(urls.batchId, batches.id), isNull(urls.deletedAt)),
-        )
+        .leftJoin(urls, and(eq(urls.batchId, batches.id), isNull(urls.deletedAt)))
         .where(
             and(
                 eq(batches.userId, locals.user.id),

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -4,6 +4,7 @@
     import Button from "$lib/components/ui/button/button.svelte";
     import Input from "$lib/components/ui/input/input.svelte";
     import * as Sheet from "$lib/components/ui/sheet/index.js";
+    import { urlSortKey } from "$lib/utils";
     import {
         Check,
         ExternalLink,
@@ -44,7 +45,8 @@
             : [...data.batches];
 
         return matches.sort((a, b) => {
-            if (sort === "name") return a.devUrl.localeCompare(b.devUrl);
+            if (sort === "name")
+                return urlSortKey(a.devUrl).localeCompare(urlSortKey(b.devUrl));
             if (sort === "needs-work")
                 return b.remainingCount - a.remainingCount;
             return (

--- a/src/routes/api/urls/[id]/+server.ts
+++ b/src/routes/api/urls/[id]/+server.ts
@@ -40,10 +40,7 @@ export async function PATCH({ locals, params, request }) {
         const original = new URL(url.url);
         const target = new URL(redirectTo, original.origin);
         if (target.toString() === original.toString()) {
-            throw error(
-                422,
-                "Redirect URL cannot be the same as the URL to redirect.",
-            );
+            throw error(422, "Redirect URL cannot be the same as the URL to redirect.");
         }
     }
 

--- a/src/routes/api/urls/[id]/check/+server.ts
+++ b/src/routes/api/urls/[id]/check/+server.ts
@@ -1,9 +1,4 @@
-import {
-    checkUrl,
-    getDevRedirectUrl,
-    getDevUrl,
-    isValidHttpUrl,
-} from "$lib/server/redirects";
+import { checkUrl, getDevRedirectUrl, getDevUrl, isValidHttpUrl } from "$lib/server/redirects";
 import { db } from "$lib/server/db";
 import { batches, urls } from "$lib/server/schema";
 import { error, json } from "@sveltejs/kit";

--- a/src/routes/batch/[id]/+page.server.ts
+++ b/src/routes/batch/[id]/+page.server.ts
@@ -14,11 +14,7 @@ import { and, asc, eq, isNull, or } from "drizzle-orm";
 
 async function getOwnedBatch(batchId: number, userId: string) {
     const batch = await db.query.batches.findFirst({
-        where: and(
-            eq(batches.id, batchId),
-            eq(batches.userId, userId),
-            isNull(batches.deletedAt),
-        ),
+        where: and(eq(batches.id, batchId), eq(batches.userId, userId), isNull(batches.deletedAt)),
     });
 
     if (!batch) {
@@ -44,22 +40,16 @@ export async function load({ locals, params }) {
         batch,
         urls: batchUrls.map((url) => ({
             ...url,
-            devUrl:
-                batch.devUrl && isValidHttpUrl(batch.devUrl)
-                    ? getDevUrl(batch, url)
-                    : "",
+            devUrl: batch.devUrl && isValidHttpUrl(batch.devUrl) ? getDevUrl(batch, url) : "",
             devRedirectUrl:
-                batch.devUrl && isValidHttpUrl(batch.devUrl)
-                    ? getDevRedirectUrl(batch, url)
-                    : "",
+                batch.devUrl && isValidHttpUrl(batch.devUrl) ? getDevRedirectUrl(batch, url) : "",
         })),
     };
 }
 
 export const actions = {
     updateDevUrl: async ({ locals, params, request }) => {
-        if (!locals.user)
-            return fail(401, { message: "You must be signed in." });
+        if (!locals.user) return fail(401, { message: "You must be signed in." });
 
         const formData = await request.formData();
         const devUrl = String(formData.get("devUrl") ?? "").trim();
@@ -89,16 +79,13 @@ export const actions = {
     },
 
     addUrls: async ({ locals, params, request }) => {
-        if (!locals.user)
-            return fail(401, { message: "You must be signed in." });
+        if (!locals.user) return fail(401, { message: "You must be signed in." });
 
         const batch = await getOwnedBatch(Number(params.id), locals.user.id);
         const formData = await request.formData();
         const input = String(formData.get("urls") ?? "");
         const candidates = [
-            ...new Set(
-                input.split("\n").map(normalizeUrlInput).filter(Boolean),
-            ),
+            ...new Set(input.split("\n").map(normalizeUrlInput).filter(Boolean)),
         ].filter(isValidHttpUrl);
 
         if (!candidates.length) {
@@ -142,8 +129,7 @@ export const actions = {
     },
 
     archive: async ({ locals, params }) => {
-        if (!locals.user)
-            return fail(401, { message: "You must be signed in." });
+        if (!locals.user) return fail(401, { message: "You must be signed in." });
 
         const batch = await getOwnedBatch(Number(params.id), locals.user.id);
         await db


### PR DESCRIPTION
## Summary

- **Fix batch name sorting** to ignore the URL protocol and a leading `www.`, so e.g. `www.thing.com` sorts before `uuu.com`. Adds a `urlSortKey` helper in `src/lib/utils.ts` used by the dashboard's name sort.
- **Switch formatting & linting to Vite+** (Oxfmt/Oxlint), replacing Prettier:
  - Reformatted JS/TS with Oxfmt.
  - `lefthook.yml` pre-commit now runs `vp fmt --write` on `.ts/.js`.
  - `package.json`: `lint` → `vp fmt --check && vp lint`, added `format` → `vp fmt --write`, removed Prettier and its plugins.
- **Add CI** (`.github/workflows/ci.yml`) that installs Vite+ (pinned `0.1.24`) and runs `vp fmt --check` + `vp lint` on PRs and pushes to `master`.

## Notes

- Oxfmt only formats JS/TS — `.svelte`, `.css`, `.md`, and `.yaml` are no longer auto-formatted (deliberate tradeoff).
- Vite+ is a user-global tool, not a project dependency; the commit hook and CI assume it's installed (CI installs it via the official script).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced URL sorting with improved case-insensitive and protocol-agnostic comparison logic.

* **Chores**
  * Updated code formatting tools and CI/CD pipeline configuration.
  * Code reformatting for improved consistency across the codebase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->