### PR TITLE
Add Next.js redirect format

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -22,6 +22,7 @@
         "@lucide/svelte": "^1.17.0",
         "@sveltejs/kit": "^2.64.0",
         "@sveltejs/vite-plugin-svelte": "^7.1.2",
+        "@types/node": "^25.9.2",
         "bits-ui": "^2.18.1",
         "drizzle-kit": "^0.31.10",
         "lefthook": "^2.1.9",
@@ -232,6 +233,8 @@
 
     "@types/estree": ["@types/estree@1.0.9", "", {}, "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg=="],
 
+    "@types/node": ["@types/node@25.9.2", "", { "dependencies": { "undici-types": ">=7.24.0 <7.24.7" } }, "sha512-G05zqtJhcDLb8uslf5EjCxXg9G1KQxiV8OS0R26IC//Eoyitzqe8z37I7cqvnZlrlSfgocQRfSn/AHBZJJFyGw=="],
+
     "@types/trusted-types": ["@types/trusted-types@2.0.7", "", {}, "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw=="],
 
     "acorn": ["acorn@8.16.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw=="],
@@ -433,6 +436,8 @@
     "tw-animate-css": ["tw-animate-css@1.4.0", "", {}, "sha512-7bziOlRqH0hJx80h/3mbicLW7o8qLsH5+RaLR2t+OHM3D0JlWGODQKQ4cxbK7WlvmUxpcj6Kgu6EKqjrGFe3QQ=="],
 
     "typescript": ["typescript@6.0.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw=="],
+
+    "undici-types": ["undici-types@7.24.6", "", {}, "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg=="],
 
     "vite": ["vite@8.0.16", "", { "dependencies": { "lightningcss": "^1.32.0", "picomatch": "^4.0.4", "postcss": "^8.5.15", "rolldown": "1.0.3", "tinyglobby": "^0.2.17" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.1.18", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw=="],
 

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
         "@lucide/svelte": "^1.17.0",
         "@sveltejs/kit": "^2.64.0",
         "@sveltejs/vite-plugin-svelte": "^7.1.2",
+        "@types/node": "^25.9.2",
         "bits-ui": "^2.18.1",
         "drizzle-kit": "^0.31.10",
         "lefthook": "^2.1.9",

--- a/src/lib/server/redirects.ts
+++ b/src/lib/server/redirects.ts
@@ -75,14 +75,6 @@ function escapeNginxQuoted(value: string) {
     return value.replaceAll("\\", "\\\\").replaceAll('"', '\\"');
 }
 
-function escapeNextJsSourcePath(value: string) {
-    return value.replace(/[(){}:*+?]/g, "\\$&");
-}
-
-function escapeNextJsRegexValue(value: string) {
-    return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-}
-
 function normalizeRedirectTarget(batch: BatchLike, url: UrlLike) {
     return new URL(getDevRedirectUrl(batch, url));
 }
@@ -172,45 +164,18 @@ function getNetlifyRedirect(batch: BatchLike, url: UrlLike) {
     return `${source} ${rule.targetPathWithQuery} 301!`;
 }
 
-function getNextJsQueryMatchers(rule: RedirectRule) {
-    return Array.from(new URLSearchParams(rule.sourceQuery).entries()).map(([key, value]) => ({
-        type: "query",
-        key,
-        value: escapeNextJsRegexValue(value),
-    }));
-}
-
 function formatNextJsProperty(name: string, value: string, indent: string) {
     return `${indent}${name}: ${JSON.stringify(value)},`;
 }
 
 function getNextJsRedirect(batch: BatchLike, url: UrlLike) {
     const rule = getRedirectRule(batch, url);
-    const lines = [
-        "      {",
-        formatNextJsProperty("source", escapeNextJsSourcePath(rule.sourcePath), "        "),
-    ];
-    const queryMatchers = getNextJsQueryMatchers(rule);
-
-    if (queryMatchers.length) {
-        lines.push("        has: [");
-        for (const matcher of queryMatchers) {
-            lines.push("          {");
-            lines.push(formatNextJsProperty("type", matcher.type, "            "));
-            lines.push(formatNextJsProperty("key", matcher.key, "            "));
-            lines.push(formatNextJsProperty("value", matcher.value, "            "));
-            lines.push("          },");
-        }
-        lines.push("        ],");
-    }
-
-    lines.push(
-        formatNextJsProperty("destination", rule.targetPathWithQuery, "        "),
-        "        permanent: true,",
-        "      },",
-    );
-
-    return lines.join("\n");
+    return [
+        "  {",
+        formatNextJsProperty("source", rule.sourcePathWithQuery, "    "),
+        formatNextJsProperty("destination", rule.targetPathWithQuery, "    "),
+        "  },",
+    ].join("\n");
 }
 
 export function getRedirectFormats(batch: BatchLike, redirectUrls: UrlLike[]) {
@@ -257,15 +222,27 @@ export function getRedirectFormats(batch: BatchLike, redirectUrls: UrlLike[]) {
         {
             id: "next-js",
             label: "Next.js",
-            filename: "next.config.js",
+            filename: "proxy.ts",
             body: [
-                "module.exports = {",
-                "  async redirects() {",
-                "    return [",
+                'import { NextResponse } from "next/server";',
+                'import type { NextRequest } from "next/server";',
+                "",
+                "const redirects = [",
                 nextJsRules.join("\n"),
-                "    ];",
-                "  },",
-                "};",
+                "] as const;",
+                "",
+                "export function proxy(request: NextRequest) {",
+                "  const requestPath = `${request.nextUrl.pathname}${request.nextUrl.search}`;",
+                "  const redirect =",
+                "    redirects.find(({ source }) => source === requestPath) ??",
+                '    redirects.find(({ source }) => !source.includes("?") && source === request.nextUrl.pathname);',
+                "",
+                "  if (!redirect) {",
+                "    return NextResponse.next();",
+                "  }",
+                "",
+                "  return NextResponse.redirect(new URL(redirect.destination, request.url), 308);",
+                "}",
             ].join("\n"),
         },
     ] satisfies RedirectFormat[];

--- a/src/lib/server/redirects.ts
+++ b/src/lib/server/redirects.ts
@@ -75,6 +75,14 @@ function escapeNginxQuoted(value: string) {
     return value.replaceAll("\\", "\\\\").replaceAll('"', '\\"');
 }
 
+function escapeNextJsSourcePath(value: string) {
+    return value.replace(/[(){}:*+?]/g, "\\$&");
+}
+
+function escapeNextJsRegexValue(value: string) {
+    return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
 function normalizeRedirectTarget(batch: BatchLike, url: UrlLike) {
     return new URL(getDevRedirectUrl(batch, url));
 }
@@ -164,6 +172,47 @@ function getNetlifyRedirect(batch: BatchLike, url: UrlLike) {
     return `${source} ${rule.targetPathWithQuery} 301!`;
 }
 
+function getNextJsQueryMatchers(rule: RedirectRule) {
+    return Array.from(new URLSearchParams(rule.sourceQuery).entries()).map(([key, value]) => ({
+        type: "query",
+        key,
+        value: escapeNextJsRegexValue(value),
+    }));
+}
+
+function formatNextJsProperty(name: string, value: string, indent: string) {
+    return `${indent}${name}: ${JSON.stringify(value)},`;
+}
+
+function getNextJsRedirect(batch: BatchLike, url: UrlLike) {
+    const rule = getRedirectRule(batch, url);
+    const lines = [
+        "      {",
+        formatNextJsProperty("source", escapeNextJsSourcePath(rule.sourcePath), "        "),
+    ];
+    const queryMatchers = getNextJsQueryMatchers(rule);
+
+    if (queryMatchers.length) {
+        lines.push("        has: [");
+        for (const matcher of queryMatchers) {
+            lines.push("          {");
+            lines.push(formatNextJsProperty("type", matcher.type, "            "));
+            lines.push(formatNextJsProperty("key", matcher.key, "            "));
+            lines.push(formatNextJsProperty("value", matcher.value, "            "));
+            lines.push("          },");
+        }
+        lines.push("        ],");
+    }
+
+    lines.push(
+        formatNextJsProperty("destination", rule.targetPathWithQuery, "        "),
+        "        permanent: true,",
+        "      },",
+    );
+
+    return lines.join("\n");
+}
+
 export function getRedirectFormats(batch: BatchLike, redirectUrls: UrlLike[]) {
     const sortedUrls = [...redirectUrls].sort((a, b) => {
         const aRule = getRedirectRule(batch, a);
@@ -178,6 +227,7 @@ export function getRedirectFormats(batch: BatchLike, redirectUrls: UrlLike[]) {
     const nginxRules = sortedUrls.map((url) => getNginxRedirect(batch, url));
     const caddyRules = sortedUrls.map((url, index) => getCaddyRedirect(batch, url, index));
     const netlifyRules = sortedUrls.map((url) => getNetlifyRedirect(batch, url));
+    const nextJsRules = sortedUrls.map((url) => getNextJsRedirect(batch, url));
 
     return [
         {
@@ -203,6 +253,20 @@ export function getRedirectFormats(batch: BatchLike, redirectUrls: UrlLike[]) {
             label: "Netlify _redirects",
             filename: "_redirects",
             body: netlifyRules.join("\n"),
+        },
+        {
+            id: "next-js",
+            label: "Next.js",
+            filename: "next.config.js",
+            body: [
+                "module.exports = {",
+                "  async redirects() {",
+                "    return [",
+                nextJsRules.join("\n"),
+                "    ];",
+                "  },",
+                "};",
+            ].join("\n"),
         },
     ] satisfies RedirectFormat[];
 }


### PR DESCRIPTION
## What changed
- Add a Next.js redirect export option to the redirects modal response formats.
- Generate `next.config.js` output with `async redirects()`, `source`, query `has` matchers, `destination`, and `permanent: true`.
- Add `@types/node` so the existing SvelteKit check can resolve Node APIs used by server code.

## Why
Users need a copyable Next.js-style redirects format alongside the existing Apache, nginx, Caddy, and Netlify outputs.

## Testing
- `bun run check`
- Focused `bun --eval` formatter check for generated Next.js redirect output
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Redirect configuration generation now supports Next.js as an output platform, complementing existing Apache, nginx, Caddy, and Netlify support. Includes specialized handling for path patterns, regex values, and query parameters.

* **Chores**
  * Updated TypeScript development dependencies for improved type coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->