### PR TITLE
Add marketing site (home, features, contact, policy pages)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Redirects Wizard
 
-Redirects Wizard is a SvelteKit app for building and checking Apache redirect rules during site migrations.
+Redirects Wizard is a SvelteKit app for building and checking redirect rules — for Apache, nginx, Caddy, and Netlify — during site migrations.
 
 ## Stack
 
@@ -92,5 +92,5 @@ bunx playwright install chromium
 1. Enter the dev URL for the site being checked.
 1. Add known production URLs, one per line.
 1. Set redirect targets for unresolved URLs.
-1. Open "View rewrites" to get Apache rewrite rules.
-1. Recheck unresolved URLs after adding the rewrites to the server.
+1. Open "View redirects" to get redirect rules for Apache, nginx, Caddy, or Netlify.
+1. Recheck unresolved URLs after adding the rules to the server.

--- a/src/app.css
+++ b/src/app.css
@@ -55,8 +55,10 @@ body {
     margin: 0;
 }
 
-a {
-    color: inherit;
+@layer base {
+    a {
+        color: inherit;
+    }
 }
 
 .dark {

--- a/src/routes/(app)/+layout.svelte
+++ b/src/routes/(app)/+layout.svelte
@@ -1,0 +1,33 @@
+<script lang="ts">
+    import { authClient } from "$lib/auth-client";
+
+    let { children } = $props();
+
+    async function signOut() {
+        await authClient.signOut();
+        window.location.href = "/login";
+    }
+</script>
+
+<div class="min-h-dvh bg-zinc-50">
+    <header class="border-b border-zinc-200 bg-white">
+        <div
+            class="mx-auto flex max-w-7xl items-center justify-between px-4 py-3 sm:px-6 lg:px-8"
+        >
+            <a href="/dashboard" class="text-base/6 font-semibold text-zinc-950"
+                >Redirects Wizard</a
+            >
+            <nav class="flex items-center gap-3 text-base/6 sm:text-sm/6">
+                <button
+                    type="button"
+                    class="font-medium text-zinc-700 hover:text-zinc-950"
+                    onclick={signOut}
+                >
+                    Sign out
+                </button>
+            </nav>
+        </div>
+    </header>
+
+    {@render children()}
+</div>

--- a/src/routes/(app)/batch/[id]/+page.server.ts
+++ b/src/routes/(app)/batch/[id]/+page.server.ts
@@ -151,6 +151,6 @@ export const actions = {
             .set({ deletedAt: new Date(), updatedAt: new Date() })
             .where(eq(batches.id, batch.id));
 
-        throw redirect(303, "/");
+        throw redirect(303, "/dashboard");
     },
 };

--- a/src/routes/(app)/batch/[id]/+page.svelte
+++ b/src/routes/(app)/batch/[id]/+page.svelte
@@ -196,7 +196,7 @@
     >
         <div class="min-w-0">
             <a
-                href="/"
+                href="/dashboard"
                 class="text-base/7 font-medium text-teal-700 sm:text-sm/6"
                 >Back to batches</a
             >

--- a/src/routes/(app)/dashboard/+page.svelte
+++ b/src/routes/(app)/dashboard/+page.svelte
@@ -74,7 +74,7 @@
                     Redirect Batches
                 </h1>
                 <p class="text-base/7 text-zinc-600 sm:text-sm/6">
-                    Manage redirect checks and Apache rewrite output.
+                    Manage redirect checks and export redirect rules.
                 </p>
             </div>
             <Sheet.Trigger>
@@ -350,7 +350,8 @@
                 </h2>
                 <p class="mt-1 max-w-sm text-base/7 text-zinc-600 sm:text-sm/6">
                     A batch groups the redirects you want to check against a dev
-                    or staging site, then generates the Apache rewrite output.
+                    or staging site, then generates redirect rules for Apache,
+                    nginx, Caddy, and Netlify.
                 </p>
                 <Sheet.Trigger>
                     {#snippet child({ props })}

--- a/src/routes/(marketing)/+layout.svelte
+++ b/src/routes/(marketing)/+layout.svelte
@@ -1,0 +1,194 @@
+<script lang="ts">
+    import { page } from "$app/state";
+    import Button from "$lib/components/ui/button/button.svelte";
+    import { Menu, X } from "lucide-svelte";
+
+    let { data, children } = $props();
+
+    let mobileOpen = $state(false);
+
+    const nav = [
+        { href: "/features", label: "Features" },
+        { href: "/contact", label: "Contact" },
+    ];
+
+    const isActive = (href: string) => page.url.pathname === href;
+</script>
+
+<div class="flex min-h-dvh flex-col bg-white">
+    <header
+        class="sticky top-0 z-40 border-b border-zinc-200 bg-white/80 backdrop-blur"
+    >
+        <div
+            class="mx-auto flex max-w-6xl items-center justify-between px-4 py-3.5 sm:px-6 lg:px-8"
+        >
+            <a
+                href="/"
+                class="flex items-center gap-2 text-base/6 font-semibold text-zinc-950"
+            >
+                <img src="/favicon.svg" alt="" class="size-7" />
+                Redirects Wizard
+            </a>
+
+            <nav class="hidden items-center gap-1 md:flex">
+                {#each nav as item (item.href)}
+                    <a
+                        href={item.href}
+                        class="rounded-md px-3 py-1.5 text-sm/6 font-medium hover:bg-zinc-100 {isActive(
+                            item.href,
+                        )
+                            ? 'text-zinc-950'
+                            : 'text-zinc-600 hover:text-zinc-950'}"
+                    >
+                        {item.label}
+                    </a>
+                {/each}
+            </nav>
+
+            <div class="hidden items-center gap-2 md:flex">
+                {#if data.user}
+                    <Button href="/dashboard">Go to dashboard</Button>
+                {:else}
+                    <a
+                        href="/login"
+                        class="rounded-md px-3 py-1.5 text-sm/6 font-medium text-zinc-700 hover:text-zinc-950"
+                    >
+                        Sign in
+                    </a>
+                    <Button href="/register">Get started</Button>
+                {/if}
+            </div>
+
+            <button
+                type="button"
+                class="rounded-md p-2 text-zinc-700 hover:bg-zinc-100 md:hidden"
+                aria-label="Toggle menu"
+                onclick={() => (mobileOpen = !mobileOpen)}
+            >
+                {#if mobileOpen}
+                    <X class="size-5" />
+                {:else}
+                    <Menu class="size-5" />
+                {/if}
+            </button>
+        </div>
+
+        {#if mobileOpen}
+            <div class="border-t border-zinc-200 bg-white md:hidden">
+                <nav class="mx-auto flex max-w-6xl flex-col gap-1 px-4 py-3">
+                    {#each nav as item (item.href)}
+                        <a
+                            href={item.href}
+                            class="rounded-md px-3 py-2 text-base/6 font-medium text-zinc-700 hover:bg-zinc-100"
+                            onclick={() => (mobileOpen = false)}
+                        >
+                            {item.label}
+                        </a>
+                    {/each}
+                    <div
+                        class="mt-2 flex flex-col gap-2 border-t border-zinc-100 pt-3"
+                    >
+                        {#if data.user}
+                            <Button href="/dashboard" class="w-full"
+                                >Go to dashboard</Button
+                            >
+                        {:else}
+                            <Button
+                                href="/login"
+                                variant="outline"
+                                class="w-full">Sign in</Button
+                            >
+                            <Button href="/register" class="w-full"
+                                >Get started</Button
+                            >
+                        {/if}
+                    </div>
+                </nav>
+            </div>
+        {/if}
+    </header>
+
+    <main class="flex-1">
+        {@render children()}
+    </main>
+
+    <footer class="border-t border-zinc-200 bg-zinc-50">
+        <div class="mx-auto max-w-6xl px-4 py-12 sm:px-6 lg:px-8">
+            <div class="flex flex-col gap-10 md:flex-row md:justify-between">
+                <div class="max-w-xs">
+                    <a
+                        href="/"
+                        class="flex items-center gap-2 text-base/6 font-semibold text-zinc-950"
+                    >
+                        <img src="/favicon.svg" alt="" class="size-7" />
+                        Redirects Wizard
+                    </a>
+                    <p class="mt-3 text-sm/6 text-zinc-600">
+                        Verify every redirect and ship clean redirect rules
+                        before your site migration goes live.
+                    </p>
+                </div>
+
+                <div class="grid grid-cols-2 gap-10 sm:grid-cols-3">
+                    <div>
+                        <h3 class="text-sm/6 font-semibold text-zinc-950">
+                            Product
+                        </h3>
+                        <ul class="mt-3 space-y-2 text-sm/6 text-zinc-600">
+                            <li>
+                                <a class="hover:text-zinc-950" href="/features"
+                                    >Features</a
+                                >
+                            </li>
+                            <li>
+                                <a class="hover:text-zinc-950" href="/register"
+                                    >Get started</a
+                                >
+                            </li>
+                            <li>
+                                <a class="hover:text-zinc-950" href="/login"
+                                    >Sign in</a
+                                >
+                            </li>
+                        </ul>
+                    </div>
+                    <div>
+                        <h3 class="text-sm/6 font-semibold text-zinc-950">
+                            Company
+                        </h3>
+                        <ul class="mt-3 space-y-2 text-sm/6 text-zinc-600">
+                            <li>
+                                <a class="hover:text-zinc-950" href="/contact"
+                                    >Contact</a
+                                >
+                            </li>
+                        </ul>
+                    </div>
+                    <div>
+                        <h3 class="text-sm/6 font-semibold text-zinc-950">
+                            Legal
+                        </h3>
+                        <ul class="mt-3 space-y-2 text-sm/6 text-zinc-600">
+                            <li>
+                                <a class="hover:text-zinc-950" href="/privacy"
+                                    >Privacy</a
+                                >
+                            </li>
+                            <li>
+                                <a class="hover:text-zinc-950" href="/terms"
+                                    >Terms</a
+                                >
+                            </li>
+                        </ul>
+                    </div>
+                </div>
+            </div>
+
+            <div
+                class="mt-10 border-t border-zinc-200 pt-6 text-sm/6 text-zinc-500"
+            >
+                © {new Date().getFullYear()} Redirects Wizard. All rights reserved.
+            </div>
+        </div>
+    </footer>
+</div>

--- a/src/routes/(marketing)/+page.svelte
+++ b/src/routes/(marketing)/+page.svelte
@@ -1,0 +1,237 @@
+<script lang="ts">
+    import Button from "$lib/components/ui/button/button.svelte";
+    import {
+        ArrowRight,
+        Check,
+        FolderPlus,
+        ListChecks,
+        FileCode2,
+        Camera,
+        Gauge,
+        ShieldCheck,
+    } from "lucide-svelte";
+
+    let { data } = $props();
+
+    const primaryCta = $derived(
+        data.user
+            ? { href: "/dashboard", label: "Go to dashboard" }
+            : { href: "/register", label: "Start checking redirects" },
+    );
+
+    const steps = [
+        {
+            icon: FolderPlus,
+            title: "Create a batch",
+            body: "Point a batch at your staging or dev site, then paste in the old URLs you need to redirect.",
+        },
+        {
+            icon: ListChecks,
+            title: "Check every redirect",
+            body: "We follow each URL, record the final destination and status code, and flag anything that misses.",
+        },
+        {
+            icon: FileCode2,
+            title: "Export the redirect rules",
+            body: "Copy production-ready rules for Apache, nginx, Caddy, or Netlify once every redirect is verified and addressed.",
+        },
+    ];
+
+    const features = [
+        {
+            icon: ListChecks,
+            title: "Bulk redirect checks",
+            body: "Validate hundreds of URLs at once and see exactly where each one lands.",
+        },
+        {
+            icon: FileCode2,
+            title: "Rules for your stack",
+            body: "Generate clean, copy-paste redirect rules for Apache, nginx, Caddy, or Netlify — ready to drop straight into your config.",
+        },
+        {
+            icon: Camera,
+            title: "Live screenshots",
+            body: "Capture a screenshot of each destination so you can confirm the page looks right.",
+        },
+        {
+            icon: Gauge,
+            title: "Progress tracking",
+            body: "Track addressed vs. pending redirects per batch so nothing slips through the cracks.",
+        },
+        {
+            icon: ShieldCheck,
+            title: "Protect your SEO",
+            body: "Catch broken or missing redirects before launch and preserve your hard-won rankings.",
+        },
+        {
+            icon: FolderPlus,
+            title: "Organized in batches",
+            body: "Group redirects by project or migration and pick up right where you left off.",
+        },
+    ];
+</script>
+
+<svelte:head>
+    <title>Redirects Wizard — Ship site migrations without losing SEO</title>
+    <meta
+        name="description"
+        content="Verify every redirect against your staging site and generate production-ready redirect rules for Apache, nginx, Caddy, and Netlify before your migration goes live."
+    />
+</svelte:head>
+
+<!-- Hero -->
+<section class="relative overflow-hidden">
+    <div
+        class="pointer-events-none absolute inset-0 -z-10 bg-linear-to-b from-teal-50/70 to-white"
+    ></div>
+    <div
+        class="mx-auto max-w-6xl px-4 pt-20 pb-16 text-center sm:px-6 sm:pt-28 lg:px-8"
+    >
+        <p
+            class="inline-flex items-center gap-1.5 rounded-full bg-teal-100 px-3 py-1 text-sm/6 font-medium text-teal-800"
+        >
+            <Check class="size-3.5" /> Built for site migrations
+        </p>
+        <h1
+            class="mx-auto mt-6 max-w-[20ch] text-4xl font-semibold tracking-tight text-balance text-zinc-950 sm:text-5xl"
+        >
+            Migrate your site without losing a single redirect
+        </h1>
+        <p class="mx-auto mt-5 max-w-2xl text-lg/8 text-pretty text-zinc-600">
+            Redirects Wizard checks every old URL against your new site, flags
+            the ones that miss, and generates production-ready redirect rules —
+            so your rankings survive launch day.
+        </p>
+        <div
+            class="mt-8 flex flex-col items-center justify-center gap-3 sm:flex-row"
+        >
+            <Button href={primaryCta.href} size="lg">
+                {primaryCta.label}
+                <ArrowRight class="size-4" />
+            </Button>
+            <Button href="/features" size="lg" variant="outline">
+                See how it works
+            </Button>
+        </div>
+        <p class="mt-4 text-sm/6 text-zinc-500">
+            No credit card required. Start your first batch in minutes.
+        </p>
+    </div>
+</section>
+
+<!-- Problem / value strip -->
+<section class="border-y border-zinc-200 bg-zinc-50">
+    <div
+        class="mx-auto grid max-w-6xl grid-cols-2 gap-px overflow-hidden px-4 py-12 sm:px-6 lg:grid-cols-4 lg:px-8"
+    >
+        {#each [{ stat: "301s", label: "Verified end to end" }, { stat: "4", label: "Export formats, ready to ship" }, { stat: "100%", label: "Coverage before launch" }, { stat: "0", label: "Surprises on go-live" }] as item (item.label)}
+            <div class="px-4 text-center">
+                <p class="text-3xl/9 font-semibold text-teal-700 tabular-nums">
+                    {item.stat}
+                </p>
+                <p class="mt-1 text-sm/6 text-zinc-600">{item.label}</p>
+            </div>
+        {/each}
+    </div>
+</section>
+
+<!-- How it works -->
+<section class="mx-auto max-w-6xl px-4 py-20 sm:px-6 lg:px-8">
+    <div class="max-w-2xl">
+        <h2
+            class="text-3xl font-semibold tracking-tight text-balance text-zinc-950"
+        >
+            Three steps to a clean migration
+        </h2>
+        <p class="mt-4 text-lg/8 text-pretty text-zinc-600">
+            From a list of old URLs to verified redirect rules — without the
+            spreadsheet.
+        </p>
+    </div>
+    <dl class="mt-14 grid gap-8 md:grid-cols-3">
+        {#each steps as step, i (step.title)}
+            <div class="relative rounded-2xl bg-white p-6 ring-1 ring-zinc-200">
+                <div
+                    class="flex size-11 items-center justify-center rounded-xl bg-teal-50 text-teal-700"
+                >
+                    <step.icon class="size-5" />
+                </div>
+                <p
+                    class="mt-4 text-sm/6 font-medium text-teal-700 tabular-nums"
+                >
+                    Step {i + 1}
+                </p>
+                <dt class="mt-1 text-lg/7 font-semibold text-zinc-950">
+                    {step.title}
+                </dt>
+                <dd class="mt-2 text-base/7 text-zinc-600">{step.body}</dd>
+            </div>
+        {/each}
+    </dl>
+</section>
+
+<!-- Features grid -->
+<section class="border-t border-zinc-200 bg-zinc-50">
+    <div class="mx-auto max-w-6xl px-4 py-20 sm:px-6 lg:px-8">
+        <div class="max-w-2xl">
+            <h2
+                class="text-3xl font-semibold tracking-tight text-balance text-zinc-950"
+            >
+                Everything you need to land the redirects
+            </h2>
+            <p class="mt-4 text-lg/8 text-pretty text-zinc-600">
+                Purpose-built for the messy reality of moving a site to a new
+                platform, structure, or domain.
+            </p>
+        </div>
+        <dl class="mt-14 grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+            {#each features as feature (feature.title)}
+                <div class="rounded-2xl bg-white p-6 ring-1 ring-zinc-200">
+                    <div
+                        class="flex size-10 items-center justify-center rounded-lg bg-teal-50 text-teal-700"
+                    >
+                        <feature.icon class="size-5" />
+                    </div>
+                    <dt class="mt-4 text-base/7 font-semibold text-zinc-950">
+                        {feature.title}
+                    </dt>
+                    <dd class="mt-1.5 text-base/7 text-zinc-600">
+                        {feature.body}
+                    </dd>
+                </div>
+            {/each}
+        </dl>
+        <div class="mt-12">
+            <Button href="/features" variant="outline">
+                Explore all features <ArrowRight class="size-4" />
+            </Button>
+        </div>
+    </div>
+</section>
+
+<!-- CTA -->
+<section class="mx-auto max-w-6xl px-4 py-20 sm:px-6 lg:px-8">
+    <div
+        class="overflow-hidden rounded-3xl bg-teal-700 px-6 py-16 text-center sm:px-16"
+    >
+        <h2
+            class="mx-auto max-w-2xl text-3xl font-semibold tracking-tight text-balance text-white"
+        >
+            Don't let a migration tank your traffic
+        </h2>
+        <p class="mx-auto mt-4 max-w-xl text-lg/8 text-pretty text-teal-50">
+            Spin up a batch, check your redirects, and walk into launch day
+            knowing every URL lands where it should.
+        </p>
+        <div class="mt-8 flex justify-center">
+            <Button
+                href={primaryCta.href}
+                size="lg"
+                class="bg-white text-teal-800 hover:bg-teal-50"
+            >
+                {primaryCta.label}
+                <ArrowRight class="size-4" />
+            </Button>
+        </div>
+    </div>
+</section>

--- a/src/routes/(marketing)/contact/+page.server.ts
+++ b/src/routes/(marketing)/contact/+page.server.ts
@@ -1,0 +1,41 @@
+import { fail } from "@sveltejs/kit";
+
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+export const actions = {
+    default: async ({ request }) => {
+        const formData = await request.formData();
+        const name = String(formData.get("name") ?? "").trim();
+        const email = String(formData.get("email") ?? "").trim();
+        const message = String(formData.get("message") ?? "").trim();
+
+        const values = { name, email, message };
+
+        if (!name || !email || !message) {
+            return fail(400, {
+                ...values,
+                message: "Please fill in your name, email, and a message.",
+            });
+        }
+
+        if (!EMAIL_RE.test(email)) {
+            return fail(400, {
+                ...values,
+                message: "Please enter a valid email address.",
+            });
+        }
+
+        if (message.length < 10) {
+            return fail(400, {
+                ...values,
+                message: "Your message is a little short — tell us a bit more.",
+            });
+        }
+
+        // The submission is recorded server-side. Wire this up to your email
+        // provider or a contact table to route it to the team.
+        console.log("[contact] new submission", { name, email, message });
+
+        return { success: true };
+    },
+};

--- a/src/routes/(marketing)/contact/+page.server.ts
+++ b/src/routes/(marketing)/contact/+page.server.ts
@@ -14,21 +14,21 @@ export const actions = {
         if (!name || !email || !message) {
             return fail(400, {
                 ...values,
-                message: "Please fill in your name, email, and a message.",
+                error: "Please fill in your name, email, and a message.",
             });
         }
 
         if (!EMAIL_RE.test(email)) {
             return fail(400, {
                 ...values,
-                message: "Please enter a valid email address.",
+                error: "Please enter a valid email address.",
             });
         }
 
         if (message.length < 10) {
             return fail(400, {
                 ...values,
-                message: "Your message is a little short — tell us a bit more.",
+                error: "Your message is a little short — tell us a bit more.",
             });
         }
 

--- a/src/routes/(marketing)/contact/+page.svelte
+++ b/src/routes/(marketing)/contact/+page.svelte
@@ -1,0 +1,175 @@
+<script lang="ts">
+    import { enhance } from "$app/forms";
+    import Button from "$lib/components/ui/button/button.svelte";
+    import Input from "$lib/components/ui/input/input.svelte";
+    import Textarea from "$lib/components/ui/textarea/textarea.svelte";
+    import { Mail, MessageSquare, CheckCircle2 } from "lucide-svelte";
+
+    let { form } = $props();
+
+    let submitting = $state(false);
+</script>
+
+<svelte:head>
+    <title>Contact — Redirects Wizard</title>
+    <meta
+        name="description"
+        content="Questions about redirects, migrations, or pricing? Get in touch with the Redirects Wizard team."
+    />
+</svelte:head>
+
+<section
+    class="border-b border-zinc-200 bg-linear-to-b from-teal-50/70 to-white"
+>
+    <div class="mx-auto max-w-6xl px-4 py-20 text-center sm:px-6 lg:px-8">
+        <h1
+            class="text-4xl font-semibold tracking-tight text-balance text-zinc-950 sm:text-5xl"
+        >
+            Get in touch
+        </h1>
+        <p class="mx-auto mt-5 max-w-2xl text-lg/8 text-pretty text-zinc-600">
+            Have a question about checking redirects, migrating a site, or
+            getting your team set up? We'd love to hear from you.
+        </p>
+    </div>
+</section>
+
+<section class="mx-auto max-w-6xl px-4 py-16 sm:px-6 lg:px-8">
+    <div class="grid gap-12 lg:grid-cols-5">
+        <!-- Info -->
+        <div class="lg:col-span-2">
+            <h2 class="text-lg/7 font-semibold text-zinc-950">
+                Talk to the team
+            </h2>
+            <p class="mt-2 text-base/7 text-zinc-600">
+                Fill out the form and we'll get back to you. For anything
+                urgent, email is the fastest way to reach us.
+            </p>
+
+            <dl class="mt-8 space-y-6">
+                <div class="flex gap-4">
+                    <div
+                        class="flex size-10 shrink-0 items-center justify-center rounded-lg bg-teal-50 text-teal-700"
+                    >
+                        <Mail class="size-5" />
+                    </div>
+                    <div>
+                        <dt class="text-sm/6 font-semibold text-zinc-950">
+                            Email
+                        </dt>
+                        <dd class="mt-0.5 text-base/7 text-zinc-600">
+                            <a
+                                class="text-teal-700 hover:text-teal-900"
+                                href="mailto:hello@redirectswizard.com"
+                                >hello@redirectswizard.com</a
+                            >
+                        </dd>
+                    </div>
+                </div>
+                <div class="flex gap-4">
+                    <div
+                        class="flex size-10 shrink-0 items-center justify-center rounded-lg bg-teal-50 text-teal-700"
+                    >
+                        <MessageSquare class="size-5" />
+                    </div>
+                    <div>
+                        <dt class="text-sm/6 font-semibold text-zinc-950">
+                            Support
+                        </dt>
+                        <dd class="mt-0.5 text-base/7 text-zinc-600">
+                            Already using Redirects Wizard? Use the in-app
+                            feedback button and we'll see it right away.
+                        </dd>
+                    </div>
+                </div>
+            </dl>
+        </div>
+
+        <!-- Form -->
+        <div class="lg:col-span-3">
+            <div class="rounded-2xl bg-white p-6 ring-1 ring-zinc-200 sm:p-8">
+                {#if form?.success}
+                    <div class="flex flex-col items-center py-10 text-center">
+                        <div
+                            class="flex size-12 items-center justify-center rounded-full bg-teal-50 text-teal-700"
+                        >
+                            <CheckCircle2 class="size-6" />
+                        </div>
+                        <h2 class="mt-4 text-lg/7 font-semibold text-zinc-950">
+                            Thanks — we got your message
+                        </h2>
+                        <p class="mt-1 max-w-sm text-base/7 text-zinc-600">
+                            We'll get back to you at the email you provided as
+                            soon as we can.
+                        </p>
+                    </div>
+                {:else}
+                    <form
+                        method="POST"
+                        class="space-y-5"
+                        use:enhance={() => {
+                            submitting = true;
+                            return async ({ update }) => {
+                                await update();
+                                submitting = false;
+                            };
+                        }}
+                    >
+                        <div>
+                            <label
+                                for="name"
+                                class="mb-1 block text-base/6 font-medium text-zinc-900 sm:text-sm/6"
+                                >Name</label
+                            >
+                            <Input
+                                id="name"
+                                name="name"
+                                autocomplete="name"
+                                value={form?.name ?? ""}
+                                required
+                            />
+                        </div>
+                        <div>
+                            <label
+                                for="email"
+                                class="mb-1 block text-base/6 font-medium text-zinc-900 sm:text-sm/6"
+                                >Email</label
+                            >
+                            <Input
+                                id="email"
+                                name="email"
+                                type="email"
+                                autocomplete="email"
+                                value={form?.email ?? ""}
+                                required
+                            />
+                        </div>
+                        <div>
+                            <label
+                                for="message"
+                                class="mb-1 block text-base/6 font-medium text-zinc-900 sm:text-sm/6"
+                                >Message</label
+                            >
+                            <Textarea
+                                id="message"
+                                name="message"
+                                rows={5}
+                                placeholder="Tell us what you're working on…"
+                                value={form?.message ?? ""}
+                                required
+                            />
+                        </div>
+                        {#if form?.message}
+                            <p class="text-base/7 text-red-700 sm:text-sm/6">
+                                {form.message}
+                            </p>
+                        {/if}
+                        <Button type="submit" disabled={submitting}>
+                            {submitting ? "Sending…" : "Send message"}
+                        </Button>
+                    </form>
+                {/if}
+            </div>
+        </div>
+    </div>
+</section>

--- a/src/routes/(marketing)/contact/+page.svelte
+++ b/src/routes/(marketing)/contact/+page.svelte
@@ -159,9 +159,9 @@
                                 required
                             />
                         </div>
-                        {#if form?.message}
+                        {#if form?.error}
                             <p class="text-base/7 text-red-700 sm:text-sm/6">
-                                {form.message}
+                                {form.error}
                             </p>
                         {/if}
                         <Button type="submit" disabled={submitting}>

--- a/src/routes/(marketing)/features/+page.svelte
+++ b/src/routes/(marketing)/features/+page.svelte
@@ -1,0 +1,242 @@
+<script lang="ts">
+    import Button from "$lib/components/ui/button/button.svelte";
+    import {
+        ArrowRight,
+        ListChecks,
+        FileCode2,
+        Camera,
+        Gauge,
+        FolderPlus,
+        ShieldCheck,
+        Search,
+        RotateCw,
+        CheckCircle2,
+    } from "lucide-svelte";
+
+    let { data } = $props();
+
+    const primaryCta = $derived(
+        data.user
+            ? { href: "/dashboard", label: "Go to dashboard" }
+            : { href: "/register", label: "Get started free" },
+    );
+
+    const sections = [
+        {
+            icon: ListChecks,
+            title: "Bulk redirect checking",
+            body: "Paste in your full list of legacy URLs and Redirects Wizard follows each one against your dev or staging site. You see the final destination, the HTTP status code, and whether the redirect resolves the way you expect — all in one pass.",
+            points: [
+                "Check entire URL lists in a single batch",
+                "See the resolved destination for every request",
+                "Spot redirect chains, loops, and dead ends instantly",
+            ],
+        },
+        {
+            icon: FileCode2,
+            title: "Redirect rules for your stack",
+            body: "Once your redirects are verified, export clean rules that are ready to drop straight into your server config — whether you run Apache, nginx, Caddy, or Netlify. No hand-editing, no typos — just copy and ship.",
+            points: [
+                "Output for Apache (.htaccess), nginx, Caddy, and Netlify",
+                "Generated only from verified redirects",
+                "Copy straight into your config or redirects file",
+            ],
+        },
+        {
+            icon: Camera,
+            title: "Destination screenshots",
+            body: "A redirect that returns a 200 isn't always the right page. Redirects Wizard captures a screenshot of each destination so you can confirm visitors land on the page you intended — not a generic homepage or error screen.",
+            points: [
+                "Automatic screenshot capture per batch",
+                "Refresh any screenshot on demand",
+                "Catch soft 404s and wrong-page redirects",
+            ],
+        },
+        {
+            icon: Gauge,
+            title: "Progress tracking",
+            body: "Every batch shows how many redirects are addressed versus still pending, with a clear progress bar. Mark redirects as handled as you work through them, and always know exactly what's left before launch.",
+            points: [
+                "Addressed vs. pending counts per batch",
+                "Visual progress bars at a glance",
+                "Filter, search, and sort by what needs work",
+            ],
+        },
+    ];
+
+    const grid = [
+        {
+            icon: FolderPlus,
+            title: "Organized batches",
+            body: "Group redirects by project, migration, or client and return to any batch later.",
+        },
+        {
+            icon: Search,
+            title: "Search & sort",
+            body: "Find batches by URL and sort by most recent, name, or what still needs work.",
+        },
+        {
+            icon: RotateCw,
+            title: "On-demand refresh",
+            body: "Re-run a check or re-capture a screenshot any time the target site changes.",
+        },
+        {
+            icon: ShieldCheck,
+            title: "SEO protection",
+            body: "Preserve link equity and rankings by verifying every redirect before go-live.",
+        },
+        {
+            icon: CheckCircle2,
+            title: "Status codes",
+            body: "See 301, 302, 404, and everything in between so you redirect with the right code.",
+        },
+        {
+            icon: Gauge,
+            title: "Launch confidence",
+            body: "Walk into launch day with a verified, exportable record of every redirect.",
+        },
+    ];
+</script>
+
+<svelte:head>
+    <title>Features — Redirects Wizard</title>
+    <meta
+        name="description"
+        content="Bulk redirect checks, multi-platform redirect rules for Apache, nginx, Caddy, and Netlify, destination screenshots, and progress tracking — everything you need to land a site migration."
+    />
+</svelte:head>
+
+<!-- Header -->
+<section
+    class="border-b border-zinc-200 bg-linear-to-b from-teal-50/70 to-white"
+>
+    <div class="mx-auto max-w-6xl px-4 py-20 text-center sm:px-6 lg:px-8">
+        <h1
+            class="mx-auto max-w-[22ch] text-4xl font-semibold tracking-tight text-balance text-zinc-950 sm:text-5xl"
+        >
+            Built to check redirects, end to end
+        </h1>
+        <p class="mx-auto mt-5 max-w-2xl text-lg/8 text-pretty text-zinc-600">
+            From verifying a thousand legacy URLs to exporting the redirect
+            rules that make them work — every step lives in one place.
+        </p>
+        <div class="mt-8 flex justify-center">
+            <Button href={primaryCta.href} size="lg">
+                {primaryCta.label}
+                <ArrowRight class="size-4" />
+            </Button>
+        </div>
+    </div>
+</section>
+
+<!-- Alternating sections -->
+<div class="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">
+    {#each sections as section, i (section.title)}
+        <section
+            class="grid items-center gap-10 border-b border-zinc-100 py-20 lg:grid-cols-2 lg:gap-16"
+        >
+            <div class={i % 2 === 1 ? "lg:order-2" : ""}>
+                <div
+                    class="flex size-12 items-center justify-center rounded-xl bg-teal-50 text-teal-700"
+                >
+                    <section.icon class="size-6" />
+                </div>
+                <h2
+                    class="mt-5 text-2xl font-semibold tracking-tight text-balance text-zinc-950"
+                >
+                    {section.title}
+                </h2>
+                <p class="mt-3 text-lg/8 text-pretty text-zinc-600">
+                    {section.body}
+                </p>
+                <ul role="list" class="mt-6 space-y-3">
+                    {#each section.points as point (point)}
+                        <li
+                            class="flex items-start gap-3 text-base/7 text-zinc-700"
+                        >
+                            <CheckCircle2
+                                class="mt-1 size-5 shrink-0 text-teal-600"
+                            />
+                            {point}
+                        </li>
+                    {/each}
+                </ul>
+            </div>
+            <div class={i % 2 === 1 ? "lg:order-1" : ""}>
+                <div
+                    class="aspect-4/3 rounded-2xl bg-linear-to-br from-teal-100 via-teal-50 to-white ring-1 ring-zinc-200"
+                >
+                    <div class="flex h-full items-center justify-center">
+                        <section.icon class="size-20 text-teal-600/40" />
+                    </div>
+                </div>
+            </div>
+        </section>
+    {/each}
+</div>
+
+<!-- Grid of smaller features -->
+<section class="bg-zinc-50">
+    <div class="mx-auto max-w-6xl px-4 py-20 sm:px-6 lg:px-8">
+        <div class="max-w-2xl">
+            <h2
+                class="text-3xl font-semibold tracking-tight text-balance text-zinc-950"
+            >
+                And the details that save you time
+            </h2>
+        </div>
+        <dl class="mt-14 grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+            {#each grid as item (item.title)}
+                <div class="rounded-2xl bg-white p-6 ring-1 ring-zinc-200">
+                    <div
+                        class="flex size-10 items-center justify-center rounded-lg bg-teal-50 text-teal-700"
+                    >
+                        <item.icon class="size-5" />
+                    </div>
+                    <dt class="mt-4 text-base/7 font-semibold text-zinc-950">
+                        {item.title}
+                    </dt>
+                    <dd class="mt-1.5 text-base/7 text-zinc-600">
+                        {item.body}
+                    </dd>
+                </div>
+            {/each}
+        </dl>
+    </div>
+</section>
+
+<!-- CTA -->
+<section class="mx-auto max-w-6xl px-4 py-20 sm:px-6 lg:px-8">
+    <div
+        class="overflow-hidden rounded-3xl bg-teal-700 px-6 py-16 text-center sm:px-16"
+    >
+        <h2
+            class="mx-auto max-w-2xl text-3xl font-semibold tracking-tight text-balance text-white"
+        >
+            Ready to verify your redirects?
+        </h2>
+        <p class="mx-auto mt-4 max-w-xl text-lg/8 text-pretty text-teal-50">
+            Create your first batch and see exactly where every URL lands.
+        </p>
+        <div
+            class="mt-8 flex flex-col items-center justify-center gap-3 sm:flex-row"
+        >
+            <Button
+                href={primaryCta.href}
+                size="lg"
+                class="bg-white text-teal-800 hover:bg-teal-50"
+            >
+                {primaryCta.label}
+                <ArrowRight class="size-4" />
+            </Button>
+            <Button
+                href="/contact"
+                size="lg"
+                variant="outline"
+                class="border-teal-400 bg-transparent text-white hover:bg-teal-600 hover:text-white"
+            >
+                Talk to us
+            </Button>
+        </div>
+    </div>
+</section>

--- a/src/routes/(marketing)/privacy/+page.svelte
+++ b/src/routes/(marketing)/privacy/+page.svelte
@@ -1,0 +1,131 @@
+<svelte:head>
+    <title>Privacy Policy — Redirects Wizard</title>
+    <meta
+        name="description"
+        content="How Redirects Wizard collects, uses, and protects your information."
+    />
+</svelte:head>
+
+<article class="mx-auto max-w-3xl px-4 py-16 sm:px-6 lg:px-8">
+    <p class="text-sm/6 font-medium text-teal-700">Legal</p>
+    <h1
+        class="mt-2 text-4xl font-semibold tracking-tight text-balance text-zinc-950"
+    >
+        Privacy Policy
+    </h1>
+    <p class="mt-3 text-sm/6 text-zinc-500">Last updated June 10, 2026</p>
+
+    <div
+        class="prose-zinc mt-10 space-y-8 text-base/7 text-zinc-700 [&_h2]:text-xl/8 [&_h2]:font-semibold [&_h2]:text-zinc-950 [&_a]:font-medium [&_a]:text-teal-700 [&_ul]:list-disc [&_ul]:space-y-1.5 [&_ul]:pl-6"
+    >
+        <p>
+            This Privacy Policy explains how Redirects Wizard ("we", "us", or
+            "our") collects, uses, and protects information when you use our
+            website and application (the "Service"). By using the Service, you
+            agree to the practices described here.
+        </p>
+
+        <section class="space-y-3">
+            <h2>Information we collect</h2>
+            <p>We collect the following types of information:</p>
+            <ul>
+                <li>
+                    <strong>Account information.</strong> When you register, we collect
+                    your name, email address, and a securely hashed password.
+                </li>
+                <li>
+                    <strong>Content you provide.</strong> The URLs, redirect targets,
+                    and dev or staging sites you add to your batches.
+                </li>
+                <li>
+                    <strong>Generated data.</strong> Redirect check results, HTTP
+                    status codes, and screenshots captured from the destinations you
+                    ask us to check.
+                </li>
+                <li>
+                    <strong>Usage data.</strong> Basic technical information such
+                    as browser type and pages visited, used to operate and improve
+                    the Service.
+                </li>
+            </ul>
+        </section>
+
+        <section class="space-y-3">
+            <h2>How we use your information</h2>
+            <p>We use the information we collect to:</p>
+            <ul>
+                <li>Provide, maintain, and improve the Service.</li>
+                <li>
+                    Run redirect checks and capture screenshots you request.
+                </li>
+                <li>Authenticate you and keep your account secure.</li>
+                <li>Respond to your questions and support requests.</li>
+            </ul>
+            <p>
+                We do not sell your personal information or the content of your
+                batches.
+            </p>
+        </section>
+
+        <section class="space-y-3">
+            <h2>Third-party services</h2>
+            <p>
+                We rely on a small number of trusted service providers to host
+                the application, store data, and capture screenshots. These
+                providers process information only as needed to deliver the
+                Service and are bound by their own privacy and security
+                obligations.
+            </p>
+        </section>
+
+        <section class="space-y-3">
+            <h2>Data retention</h2>
+            <p>
+                We retain your account information and batch content for as long
+                as your account is active. You may delete batches at any time,
+                and you can request deletion of your account and associated data
+                by contacting us.
+            </p>
+        </section>
+
+        <section class="space-y-3">
+            <h2>Security</h2>
+            <p>
+                We take reasonable technical and organizational measures to
+                protect your information, including encrypted transport and
+                hashed passwords. No method of transmission or storage is
+                completely secure, but we work to safeguard your data.
+            </p>
+        </section>
+
+        <section class="space-y-3">
+            <h2>Your rights</h2>
+            <p>
+                Depending on where you live, you may have the right to access,
+                correct, or delete your personal information, or to object to
+                certain processing. To exercise these rights, contact us using
+                the details below.
+            </p>
+        </section>
+
+        <section class="space-y-3">
+            <h2>Changes to this policy</h2>
+            <p>
+                We may update this Privacy Policy from time to time. When we do,
+                we will revise the "Last updated" date above. Significant
+                changes will be communicated through the Service.
+            </p>
+        </section>
+
+        <section class="space-y-3">
+            <h2>Contact us</h2>
+            <p>
+                Questions about this policy? Reach us at <a
+                    href="mailto:hello@redirectswizard.com"
+                    >hello@redirectswizard.com</a
+                >
+                or through our <a href="/contact">contact page</a>.
+            </p>
+        </section>
+    </div>
+</article>

--- a/src/routes/(marketing)/terms/+page.svelte
+++ b/src/routes/(marketing)/terms/+page.svelte
@@ -1,0 +1,124 @@
+<svelte:head>
+    <title>Terms of Service — Redirects Wizard</title>
+    <meta
+        name="description"
+        content="The terms that govern your use of Redirects Wizard."
+    />
+</svelte:head>
+
+<article class="mx-auto max-w-3xl px-4 py-16 sm:px-6 lg:px-8">
+    <p class="text-sm/6 font-medium text-teal-700">Legal</p>
+    <h1
+        class="mt-2 text-4xl font-semibold tracking-tight text-balance text-zinc-950"
+    >
+        Terms of Service
+    </h1>
+    <p class="mt-3 text-sm/6 text-zinc-500">Last updated June 10, 2026</p>
+
+    <div
+        class="prose-zinc mt-10 space-y-8 text-base/7 text-zinc-700 [&_h2]:text-xl/8 [&_h2]:font-semibold [&_h2]:text-zinc-950 [&_a]:font-medium [&_a]:text-teal-700 [&_ul]:list-disc [&_ul]:space-y-1.5 [&_ul]:pl-6"
+    >
+        <p>
+            These Terms of Service ("Terms") govern your access to and use of
+            Redirects Wizard (the "Service"). By creating an account or using
+            the Service, you agree to be bound by these Terms. If you do not
+            agree, do not use the Service.
+        </p>
+
+        <section class="space-y-3">
+            <h2>Using the Service</h2>
+            <p>
+                You must be at least 18 years old, or the age of majority in
+                your jurisdiction, to use the Service. You are responsible for
+                maintaining the confidentiality of your account credentials and
+                for all activity that occurs under your account.
+            </p>
+        </section>
+
+        <section class="space-y-3">
+            <h2>Acceptable use</h2>
+            <p>You agree not to:</p>
+            <ul>
+                <li>
+                    Use the Service to check or capture content from sites you
+                    do not own or have permission to test.
+                </li>
+                <li>
+                    Attempt to disrupt, overload, or gain unauthorized access to
+                    the Service or its infrastructure.
+                </li>
+                <li>
+                    Use the Service for any unlawful, infringing, or abusive
+                    purpose.
+                </li>
+                <li>
+                    Reverse engineer or resell the Service without our written
+                    permission.
+                </li>
+            </ul>
+        </section>
+
+        <section class="space-y-3">
+            <h2>Your content</h2>
+            <p>
+                You retain ownership of the URLs, redirect data, and other
+                content you add to the Service. You grant us a limited license
+                to process that content solely to operate the Service on your
+                behalf — for example, to follow redirects and capture
+                screenshots you request.
+            </p>
+        </section>
+
+        <section class="space-y-3">
+            <h2>Service availability</h2>
+            <p>
+                We work to keep the Service available and accurate, but it is
+                provided "as is" without warranties of any kind. Redirect checks
+                and screenshots reflect the state of the target site at the time
+                of the check and may change. You are responsible for verifying
+                your final configuration before deploying it to production.
+            </p>
+        </section>
+
+        <section class="space-y-3">
+            <h2>Limitation of liability</h2>
+            <p>
+                To the fullest extent permitted by law, Redirects Wizard will
+                not be liable for any indirect, incidental, or consequential
+                damages, or for any loss of data, traffic, revenue, or rankings
+                arising from your use of the Service.
+            </p>
+        </section>
+
+        <section class="space-y-3">
+            <h2>Termination</h2>
+            <p>
+                You may stop using the Service and delete your account at any
+                time. We may suspend or terminate access if you violate these
+                Terms or use the Service in a way that risks harm to others or
+                to our infrastructure.
+            </p>
+        </section>
+
+        <section class="space-y-3">
+            <h2>Changes to these Terms</h2>
+            <p>
+                We may update these Terms from time to time. When we do, we will
+                revise the "Last updated" date above. Continued use of the
+                Service after changes take effect constitutes acceptance of the
+                revised Terms.
+            </p>
+        </section>
+
+        <section class="space-y-3">
+            <h2>Contact us</h2>
+            <p>
+                Questions about these Terms? Reach us at <a
+                    href="mailto:hello@redirectswizard.com"
+                    >hello@redirectswizard.com</a
+                >
+                or through our <a href="/contact">contact page</a>.
+            </p>
+        </section>
+    </div>
+</article>

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,14 +1,8 @@
 <script lang="ts">
     import "../app.css";
-    import { authClient } from "$lib/auth-client";
     import { onMount } from "svelte";
 
     let { data, children } = $props();
-
-    async function signOut() {
-        await authClient.signOut();
-        window.location.href = "/login";
-    }
 
     onMount(() => {
         if (!data.user) return;
@@ -35,27 +29,4 @@
     <title>Redirects Wizard</title>
 </svelte:head>
 
-<div class="min-h-screen bg-zinc-50">
-    <header class="border-b border-zinc-200 bg-white">
-        <div
-            class="mx-auto flex max-w-7xl items-center justify-between px-4 py-3 sm:px-6 lg:px-8"
-        >
-            <a href="/" class="text-base/6 font-semibold text-zinc-950"
-                >Redirects Wizard</a
-            >
-            {#if data.user}
-                <nav class="flex items-center gap-3 text-base/6 sm:text-sm/6">
-                    <button
-                        type="button"
-                        class="font-medium text-zinc-700 hover:text-zinc-950"
-                        onclick={signOut}
-                    >
-                        Sign out
-                    </button>
-                </nav>
-            {/if}
-        </div>
-    </header>
-
-    {@render children()}
-</div>
+{@render children()}

--- a/src/routes/login/+page.server.ts
+++ b/src/routes/login/+page.server.ts
@@ -2,6 +2,6 @@ import { redirect } from "@sveltejs/kit";
 
 export function load({ locals }) {
     if (locals.user) {
-        throw redirect(303, "/");
+        throw redirect(303, "/dashboard");
     }
 }

--- a/src/routes/login/+page.svelte
+++ b/src/routes/login/+page.svelte
@@ -24,12 +24,12 @@
             return;
         }
 
-        window.location.href = "/";
+        window.location.href = "/dashboard";
     }
 </script>
 
 <main
-    class="mx-auto flex min-h-[calc(100vh-57px)] max-w-7xl items-center justify-center px-4 py-10 sm:px-6 lg:px-8"
+    class="mx-auto flex min-h-dvh max-w-7xl items-center justify-center px-4 py-10 sm:px-6 lg:px-8"
 >
     <section
         class="w-full max-w-xs rounded-lg bg-white p-5 ring-1 ring-zinc-200"

--- a/src/routes/register/+page.server.ts
+++ b/src/routes/register/+page.server.ts
@@ -2,6 +2,6 @@ import { redirect } from "@sveltejs/kit";
 
 export function load({ locals }) {
     if (locals.user) {
-        throw redirect(303, "/");
+        throw redirect(303, "/dashboard");
     }
 }

--- a/src/routes/register/+page.svelte
+++ b/src/routes/register/+page.svelte
@@ -26,12 +26,12 @@
             return;
         }
 
-        window.location.href = "/";
+        window.location.href = "/dashboard";
     }
 </script>
 
 <main
-    class="mx-auto flex min-h-[calc(100vh-57px)] max-w-7xl items-center justify-center px-4 py-10 sm:px-6 lg:px-8"
+    class="mx-auto flex min-h-dvh max-w-7xl items-center justify-center px-4 py-10 sm:px-6 lg:px-8"
 >
     <section
         class="w-full max-w-xs rounded-lg bg-white p-5 ring-1 ring-zinc-200"


### PR DESCRIPTION
## Summary

Adds a public marketing site around the existing redirect-checking app, and splits the app behind a route group so the two have distinct chrome.

- **New `(marketing)` route group** with a shared header (sticky nav + mobile menu) and footer:
  - `/` — home (hero, value stats, three-step flow, feature grid, CTA)
  - `/features` — alternating feature spotlights + details grid
  - `/contact` — contact form backed by a server action with validation and a success state
  - `/privacy` and `/terms` — policy pages
- **Split the app into an `(app)` route group:** the dashboard moves to `/dashboard` (batch pages stay at `/batch/[id]`), each under an app-chrome layout. Post-auth redirects, the root layout, and the login/register pages are updated to match.
- **Copy reflects all supported output formats** — redirect rules export for Apache, nginx, Caddy, and Netlify, not Apache only (marketing pages, dashboard, and README).
- **Header/footer use the favicon brand mark.**

## Notes

- The contact form action currently logs submissions server-side; there's a comment marking where to wire up email/storage. Placeholder address `hello@redirectswizard.com` is used in the contact page and policy pages.
- Marketing pages were reviewed against the UI design guidelines (deprecated utilities, line-height tokens, `<dl>` semantics, layout balance).

## Bugfix included

`fix: scope global anchor color to @layer base` — the unlayered `a { color: inherit }` rule was overriding Tailwind's text-color utilities, so link-styled buttons (anchors with `href`) inherited body text instead of their intended foreground color. This affected buttons app-wide, not just the marketing pages.

## Stacking

Based on `chore/npm-updates` (PR #106) since this branch is stacked on it; will auto-retarget to `master` when that merges.

## Verification

- `bun run check` — 0 errors, 0 warnings
- `bun run build` — succeeds, routes resolve with no group conflicts
- Manually verified all pages render (200s; `/dashboard` redirects to login when unauthenticated) and the contact form validation + success flow