### PR TITLE
Rename "Dev URL" field to "Base URL"

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ it via `CHROMIUM_PATH`, so no separate screenshot service is required.
 
 Captured images are written to `SCREENSHOTS_DIR`. Mount a **persistent volume**
 at that path in Dokploy (e.g. `/data/screenshots`) so screenshots survive
-redeploys. Screenshots are (re)captured when a batch's dev URL is set and via
+redeploys. Screenshots are (re)captured when a batch's base URL is set and via
 the refresh button on each batch card.
 
 For local development, install the browser once:
@@ -89,7 +89,7 @@ bunx playwright install chromium
 ## Building redirects
 
 1. Create a batch from the dashboard.
-1. Enter the dev URL for the site being checked.
+1. Enter the base URL for the site being checked (dev, staging, or live).
 1. Add known production URLs, one per line.
 1. Set redirect targets for unresolved URLs.
 1. Open "View redirects" to get redirect rules for Apache, nginx, Caddy, Netlify, or Next.js.

--- a/drizzle/0002_chunky_paper_doll.sql
+++ b/drizzle/0002_chunky_paper_doll.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "batches" RENAME COLUMN "dev_url" TO "base_url";

--- a/drizzle/meta/0002_snapshot.json
+++ b/drizzle/meta/0002_snapshot.json
@@ -1,0 +1,516 @@
+{
+    "id": "186a9b7d-55b4-4677-93a3-33bef4d322a5",
+    "prevId": "a50ccc3c-2f9c-4b49-9bab-3a1407351839",
+    "version": "7",
+    "dialect": "postgresql",
+    "tables": {
+        "public.account": {
+            "name": "account",
+            "schema": "",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "text",
+                    "primaryKey": true,
+                    "notNull": true
+                },
+                "account_id": {
+                    "name": "account_id",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "provider_id": {
+                    "name": "provider_id",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "user_id": {
+                    "name": "user_id",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "access_token": {
+                    "name": "access_token",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "refresh_token": {
+                    "name": "refresh_token",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "id_token": {
+                    "name": "id_token",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "access_token_expires_at": {
+                    "name": "access_token_expires_at",
+                    "type": "timestamp",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "refresh_token_expires_at": {
+                    "name": "refresh_token_expires_at",
+                    "type": "timestamp",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "scope": {
+                    "name": "scope",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "password": {
+                    "name": "password",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "created_at": {
+                    "name": "created_at",
+                    "type": "timestamp",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                },
+                "updated_at": {
+                    "name": "updated_at",
+                    "type": "timestamp",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                }
+            },
+            "indexes": {},
+            "foreignKeys": {
+                "account_user_id_user_id_fk": {
+                    "name": "account_user_id_user_id_fk",
+                    "tableFrom": "account",
+                    "tableTo": "user",
+                    "columnsFrom": [
+                        "user_id"
+                    ],
+                    "columnsTo": [
+                        "id"
+                    ],
+                    "onDelete": "cascade",
+                    "onUpdate": "no action"
+                }
+            },
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.batches": {
+            "name": "batches",
+            "schema": "",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "serial",
+                    "primaryKey": true,
+                    "notNull": true
+                },
+                "user_id": {
+                    "name": "user_id",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "base_url": {
+                    "name": "base_url",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "''"
+                },
+                "screenshot_updated_at": {
+                    "name": "screenshot_updated_at",
+                    "type": "timestamp",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "created_at": {
+                    "name": "created_at",
+                    "type": "timestamp",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                },
+                "updated_at": {
+                    "name": "updated_at",
+                    "type": "timestamp",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                },
+                "deleted_at": {
+                    "name": "deleted_at",
+                    "type": "timestamp",
+                    "primaryKey": false,
+                    "notNull": false
+                }
+            },
+            "indexes": {
+                "batches_user_id_idx": {
+                    "name": "batches_user_id_idx",
+                    "columns": [
+                        {
+                            "expression": "user_id",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                }
+            },
+            "foreignKeys": {
+                "batches_user_id_user_id_fk": {
+                    "name": "batches_user_id_user_id_fk",
+                    "tableFrom": "batches",
+                    "tableTo": "user",
+                    "columnsFrom": [
+                        "user_id"
+                    ],
+                    "columnsTo": [
+                        "id"
+                    ],
+                    "onDelete": "cascade",
+                    "onUpdate": "no action"
+                }
+            },
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.session": {
+            "name": "session",
+            "schema": "",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "text",
+                    "primaryKey": true,
+                    "notNull": true
+                },
+                "expires_at": {
+                    "name": "expires_at",
+                    "type": "timestamp",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "token": {
+                    "name": "token",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "created_at": {
+                    "name": "created_at",
+                    "type": "timestamp",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                },
+                "updated_at": {
+                    "name": "updated_at",
+                    "type": "timestamp",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                },
+                "ip_address": {
+                    "name": "ip_address",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "user_agent": {
+                    "name": "user_agent",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "user_id": {
+                    "name": "user_id",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                }
+            },
+            "indexes": {},
+            "foreignKeys": {
+                "session_user_id_user_id_fk": {
+                    "name": "session_user_id_user_id_fk",
+                    "tableFrom": "session",
+                    "tableTo": "user",
+                    "columnsFrom": [
+                        "user_id"
+                    ],
+                    "columnsTo": [
+                        "id"
+                    ],
+                    "onDelete": "cascade",
+                    "onUpdate": "no action"
+                }
+            },
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {
+                "session_token_unique": {
+                    "name": "session_token_unique",
+                    "nullsNotDistinct": false,
+                    "columns": [
+                        "token"
+                    ]
+                }
+            },
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.urls": {
+            "name": "urls",
+            "schema": "",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "serial",
+                    "primaryKey": true,
+                    "notNull": true
+                },
+                "batch_id": {
+                    "name": "batch_id",
+                    "type": "integer",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "url": {
+                    "name": "url",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "redirect_to": {
+                    "name": "redirect_to",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "http_response": {
+                    "name": "http_response",
+                    "type": "jsonb",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "addressed": {
+                    "name": "addressed",
+                    "type": "boolean",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": false
+                },
+                "deleted_at": {
+                    "name": "deleted_at",
+                    "type": "timestamp",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "created_at": {
+                    "name": "created_at",
+                    "type": "timestamp",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                },
+                "updated_at": {
+                    "name": "updated_at",
+                    "type": "timestamp",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                }
+            },
+            "indexes": {
+                "urls_batch_id_idx": {
+                    "name": "urls_batch_id_idx",
+                    "columns": [
+                        {
+                            "expression": "batch_id",
+                            "isExpression": false,
+                            "asc": true,
+                            "nulls": "last"
+                        }
+                    ],
+                    "isUnique": false,
+                    "concurrently": false,
+                    "method": "btree",
+                    "with": {}
+                }
+            },
+            "foreignKeys": {
+                "urls_batch_id_batches_id_fk": {
+                    "name": "urls_batch_id_batches_id_fk",
+                    "tableFrom": "urls",
+                    "tableTo": "batches",
+                    "columnsFrom": [
+                        "batch_id"
+                    ],
+                    "columnsTo": [
+                        "id"
+                    ],
+                    "onDelete": "cascade",
+                    "onUpdate": "no action"
+                }
+            },
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.user": {
+            "name": "user",
+            "schema": "",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "text",
+                    "primaryKey": true,
+                    "notNull": true
+                },
+                "name": {
+                    "name": "name",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "email": {
+                    "name": "email",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "email_verified": {
+                    "name": "email_verified",
+                    "type": "boolean",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": false
+                },
+                "image": {
+                    "name": "image",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": false
+                },
+                "created_at": {
+                    "name": "created_at",
+                    "type": "timestamp",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                },
+                "updated_at": {
+                    "name": "updated_at",
+                    "type": "timestamp",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                }
+            },
+            "indexes": {},
+            "foreignKeys": {},
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {
+                "user_email_unique": {
+                    "name": "user_email_unique",
+                    "nullsNotDistinct": false,
+                    "columns": [
+                        "email"
+                    ]
+                }
+            },
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        },
+        "public.verification": {
+            "name": "verification",
+            "schema": "",
+            "columns": {
+                "id": {
+                    "name": "id",
+                    "type": "text",
+                    "primaryKey": true,
+                    "notNull": true
+                },
+                "identifier": {
+                    "name": "identifier",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "value": {
+                    "name": "value",
+                    "type": "text",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "expires_at": {
+                    "name": "expires_at",
+                    "type": "timestamp",
+                    "primaryKey": false,
+                    "notNull": true
+                },
+                "created_at": {
+                    "name": "created_at",
+                    "type": "timestamp",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                },
+                "updated_at": {
+                    "name": "updated_at",
+                    "type": "timestamp",
+                    "primaryKey": false,
+                    "notNull": true,
+                    "default": "now()"
+                }
+            },
+            "indexes": {},
+            "foreignKeys": {},
+            "compositePrimaryKeys": {},
+            "uniqueConstraints": {},
+            "policies": {},
+            "checkConstraints": {},
+            "isRLSEnabled": false
+        }
+    },
+    "enums": {},
+    "schemas": {},
+    "sequences": {},
+    "roles": {},
+    "policies": {},
+    "views": {},
+    "_meta": {
+        "columns": {},
+        "schemas": {},
+        "tables": {}
+    }
+}

--- a/drizzle/meta/0002_snapshot.json
+++ b/drizzle/meta/0002_snapshot.json
@@ -95,12 +95,8 @@
                     "name": "account_user_id_user_id_fk",
                     "tableFrom": "account",
                     "tableTo": "user",
-                    "columnsFrom": [
-                        "user_id"
-                    ],
-                    "columnsTo": [
-                        "id"
-                    ],
+                    "columnsFrom": ["user_id"],
+                    "columnsTo": ["id"],
                     "onDelete": "cascade",
                     "onUpdate": "no action"
                 }
@@ -183,12 +179,8 @@
                     "name": "batches_user_id_user_id_fk",
                     "tableFrom": "batches",
                     "tableTo": "user",
-                    "columnsFrom": [
-                        "user_id"
-                    ],
-                    "columnsTo": [
-                        "id"
-                    ],
+                    "columnsFrom": ["user_id"],
+                    "columnsTo": ["id"],
                     "onDelete": "cascade",
                     "onUpdate": "no action"
                 }
@@ -260,12 +252,8 @@
                     "name": "session_user_id_user_id_fk",
                     "tableFrom": "session",
                     "tableTo": "user",
-                    "columnsFrom": [
-                        "user_id"
-                    ],
-                    "columnsTo": [
-                        "id"
-                    ],
+                    "columnsFrom": ["user_id"],
+                    "columnsTo": ["id"],
                     "onDelete": "cascade",
                     "onUpdate": "no action"
                 }
@@ -275,9 +263,7 @@
                 "session_token_unique": {
                     "name": "session_token_unique",
                     "nullsNotDistinct": false,
-                    "columns": [
-                        "token"
-                    ]
+                    "columns": ["token"]
                 }
             },
             "policies": {},
@@ -368,12 +354,8 @@
                     "name": "urls_batch_id_batches_id_fk",
                     "tableFrom": "urls",
                     "tableTo": "batches",
-                    "columnsFrom": [
-                        "batch_id"
-                    ],
-                    "columnsTo": [
-                        "id"
-                    ],
+                    "columnsFrom": ["batch_id"],
+                    "columnsTo": ["id"],
                     "onDelete": "cascade",
                     "onUpdate": "no action"
                 }
@@ -441,9 +423,7 @@
                 "user_email_unique": {
                     "name": "user_email_unique",
                     "nullsNotDistinct": false,
-                    "columns": [
-                        "email"
-                    ]
+                    "columns": ["email"]
                 }
             },
             "policies": {},

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -15,6 +15,13 @@
             "when": 1781039931249,
             "tag": "0001_oval_spectrum",
             "breakpoints": true
+        },
+        {
+            "idx": 2,
+            "version": "7",
+            "when": 1781100000000,
+            "tag": "0002_chunky_paper_doll",
+            "breakpoints": true
         }
     ]
 }

--- a/src/lib/server/redirects.ts
+++ b/src/lib/server/redirects.ts
@@ -1,7 +1,7 @@
 import type { HttpResponse } from "./schema";
 
 type BatchLike = {
-    devUrl: string;
+    baseUrl: string;
 };
 
 type UrlLike = {
@@ -43,20 +43,20 @@ export function isValidHttpUrl(value: string) {
     }
 }
 
-export function getDevUrl(batch: BatchLike, url: UrlLike) {
+export function getBaseUrl(batch: BatchLike, url: UrlLike) {
     const current = new URL(url.url);
-    const dev = new URL(batch.devUrl);
-    const next = new URL(dev.origin);
+    const base = new URL(batch.baseUrl);
+    const next = new URL(base.origin);
     next.pathname = current.pathname;
     next.search = current.search;
     return next.toString();
 }
 
-export function getDevRedirectUrl(batch: BatchLike, url: UrlLike) {
-    const dev = new URL(batch.devUrl);
-    const next = new URL(dev.origin);
+export function getBaseRedirectUrl(batch: BatchLike, url: UrlLike) {
+    const base = new URL(batch.baseUrl);
+    const next = new URL(base.origin);
     if (url.redirectTo) {
-        const redirect = new URL(url.redirectTo, dev.origin);
+        const redirect = new URL(url.redirectTo, base.origin);
         next.pathname = redirect.pathname;
         next.search = redirect.search;
     }
@@ -76,7 +76,7 @@ function escapeNginxQuoted(value: string) {
 }
 
 function normalizeRedirectTarget(batch: BatchLike, url: UrlLike) {
-    return new URL(getDevRedirectUrl(batch, url));
+    return new URL(getBaseRedirectUrl(batch, url));
 }
 
 function getRedirectRule(batch: BatchLike, url: UrlLike): RedirectRule {

--- a/src/lib/server/schema.ts
+++ b/src/lib/server/schema.ts
@@ -80,7 +80,7 @@ export const batches = pgTable(
         userId: text("user_id")
             .notNull()
             .references(() => user.id, { onDelete: "cascade" }),
-        devUrl: text("dev_url").notNull().default(""),
+        baseUrl: text("base_url").notNull().default(""),
         screenshotUpdatedAt: timestamp("screenshot_updated_at"),
         createdAt: timestamp("created_at").notNull().defaultNow(),
         updatedAt: timestamp("updated_at").notNull().defaultNow(),

--- a/src/lib/server/screenshots.ts
+++ b/src/lib/server/screenshots.ts
@@ -145,7 +145,7 @@ async function preparePageForScreenshot(page: Page): Promise<void> {
     });
 }
 
-async function captureOnce(batchId: number, devUrl: string, mode: CaptureMode): Promise<void> {
+async function captureOnce(batchId: number, baseUrl: string, mode: CaptureMode): Promise<void> {
     const browser = await getBrowser();
     const context = await browser.newContext({
         viewport: VIEWPORT,
@@ -168,7 +168,7 @@ async function captureOnce(batchId: number, devUrl: string, mode: CaptureMode): 
         const page = await context.newPage();
 
         try {
-            await page.goto(devUrl, {
+            await page.goto(baseUrl, {
                 waitUntil: "domcontentloaded",
                 timeout: NAV_TIMEOUT,
             });
@@ -200,14 +200,14 @@ async function captureOnce(batchId: number, devUrl: string, mode: CaptureMode): 
     }
 }
 
-// Capture devUrl to disk and stamp the batch so the UI knows a screenshot
+// Capture baseUrl to disk and stamp the batch so the UI knows a screenshot
 // exists (and can cache-bust on the new timestamp). Best-effort on navigation:
 // if the page never fully settles we still capture whatever rendered. Some
 // pages crash the renderer ("Target crashed") with their own scripts running,
 // so the fallback retries as a static document with JavaScript disabled.
-export async function captureScreenshot(batchId: number, devUrl: string): Promise<void> {
+export async function captureScreenshot(batchId: number, baseUrl: string): Promise<void> {
     console.log(
-        `[screenshot] capturing batch ${batchId} (${devUrl}) → ${screenshotFilePath(batchId)}; chromium=${env.CHROMIUM_PATH || "(bundled)"}`,
+        `[screenshot] capturing batch ${batchId} (${baseUrl}) → ${screenshotFilePath(batchId)}; chromium=${env.CHROMIUM_PATH || "(bundled)"}`,
     );
 
     let lastError: unknown;
@@ -216,7 +216,7 @@ export async function captureScreenshot(batchId: number, devUrl: string): Promis
         const mode = CAPTURE_MODES[attempt - 1];
 
         try {
-            await captureOnce(batchId, devUrl, mode);
+            await captureOnce(batchId, baseUrl, mode);
             console.log(`[screenshot] captured batch ${batchId} using ${mode.name} mode`);
             return;
         } catch (error) {

--- a/src/routes/(app)/batch/[id]/+page.server.ts
+++ b/src/routes/(app)/batch/[id]/+page.server.ts
@@ -38,12 +38,14 @@ export async function load({ locals, params }) {
 
     return {
         batch,
-        urls: batchUrls.map((url) => ({
-            ...url,
-            baseUrl: batch.baseUrl && isValidHttpUrl(batch.baseUrl) ? getBaseUrl(batch, url) : "",
-            baseRedirectUrl:
-                batch.baseUrl && isValidHttpUrl(batch.baseUrl) ? getBaseRedirectUrl(batch, url) : "",
-        })),
+        urls: batchUrls.map((url) => {
+            const hasBaseUrl = !!batch.baseUrl && isValidHttpUrl(batch.baseUrl);
+            return {
+                ...url,
+                baseUrl: hasBaseUrl ? getBaseUrl(batch, url) : "",
+                baseRedirectUrl: hasBaseUrl ? getBaseRedirectUrl(batch, url) : "",
+            };
+        }),
     };
 }
 

--- a/src/routes/(app)/batch/[id]/+page.server.ts
+++ b/src/routes/(app)/batch/[id]/+page.server.ts
@@ -1,7 +1,7 @@
 import {
     checkUrl,
-    getDevRedirectUrl,
-    getDevUrl,
+    getBaseRedirectUrl,
+    getBaseUrl,
     isValidHttpUrl,
     normalizeUrlInput,
     withoutTrailingSlash,
@@ -40,42 +40,42 @@ export async function load({ locals, params }) {
         batch,
         urls: batchUrls.map((url) => ({
             ...url,
-            devUrl: batch.devUrl && isValidHttpUrl(batch.devUrl) ? getDevUrl(batch, url) : "",
-            devRedirectUrl:
-                batch.devUrl && isValidHttpUrl(batch.devUrl) ? getDevRedirectUrl(batch, url) : "",
+            baseUrl: batch.baseUrl && isValidHttpUrl(batch.baseUrl) ? getBaseUrl(batch, url) : "",
+            baseRedirectUrl:
+                batch.baseUrl && isValidHttpUrl(batch.baseUrl) ? getBaseRedirectUrl(batch, url) : "",
         })),
     };
 }
 
 export const actions = {
-    updateDevUrl: async ({ locals, params, request }) => {
+    updateBaseUrl: async ({ locals, params, request }) => {
         if (!locals.user) return fail(401, { message: "You must be signed in." });
 
         const formData = await request.formData();
-        const devUrl = String(formData.get("devUrl") ?? "").trim();
+        const baseUrl = String(formData.get("baseUrl") ?? "").trim();
 
-        if (!isValidHttpUrl(devUrl)) {
+        if (!isValidHttpUrl(baseUrl)) {
             return fail(400, {
-                message: "Enter a valid dev URL including http:// or https://.",
+                message: "Enter a valid base URL including http:// or https://.",
             });
         }
 
         const batch = await getOwnedBatch(Number(params.id), locals.user.id);
         await db
             .update(batches)
-            .set({ devUrl, updatedAt: new Date() })
+            .set({ baseUrl, updatedAt: new Date() })
             .where(eq(batches.id, batch.id));
 
         try {
-            await captureScreenshot(batch.id, devUrl);
+            await captureScreenshot(batch.id, baseUrl);
         } catch (error) {
-            console.error("[screenshot] capture failed on updateDevUrl", error);
+            console.error("[screenshot] capture failed on updateBaseUrl", error);
             return {
-                success: "Dev URL updated. Screenshot could not be generated.",
+                success: "Base URL updated. Screenshot could not be generated.",
             };
         }
 
-        return { success: "Dev URL updated." };
+        return { success: "Base URL updated." };
     },
 
     addUrls: async ({ locals, params, request }) => {
@@ -109,8 +109,8 @@ export const actions = {
                 .insert(urls)
                 .values({ batchId: batch.id, url: candidate })
                 .returning();
-            const response = isValidHttpUrl(batch.devUrl)
-                ? await checkUrl(getDevUrl(batch, created))
+            const response = isValidHttpUrl(batch.baseUrl)
+                ? await checkUrl(getBaseUrl(batch, created))
                 : null;
 
             await db

--- a/src/routes/(app)/batch/[id]/+page.svelte
+++ b/src/routes/(app)/batch/[id]/+page.svelte
@@ -60,7 +60,7 @@
         }
     });
 
-    const validDevUrl = $derived(Boolean(data.batch.devUrl));
+    const validBaseUrl = $derived(Boolean(data.batch.baseUrl));
     const addressedCount = $derived(
         urlRows.filter((url) => url.addressed).length,
     );
@@ -160,10 +160,10 @@
 
     function getDisplayUrl(value: string) {
         try {
-            const devUrl = new URL(data.batch.devUrl);
-            const candidate = new URL(value, devUrl.origin);
+            const baseUrl = new URL(data.batch.baseUrl);
+            const candidate = new URL(value, baseUrl.origin);
 
-            if (candidate.origin !== devUrl.origin) return value;
+            if (candidate.origin !== baseUrl.origin) return value;
 
             return `${candidate.pathname}${candidate.search}${candidate.hash}`;
         } catch {
@@ -257,14 +257,14 @@
                 Back to batches
             </a>
             <h1 class="mt-2 truncate text-2xl/8 font-semibold text-zinc-950">
-                {data.batch.devUrl || "New redirect batch"}
+                {data.batch.baseUrl || "New redirect batch"}
             </h1>
             <p class="mt-1 text-base/7 text-zinc-600 sm:text-sm/6">
                 Review live URL checks, add redirect targets, and export rewrite rules.
             </p>
         </div>
 
-        {#if validDevUrl}
+        {#if validBaseUrl}
             <Dialog.Root bind:open={redirectsOpen}>
                 <Dialog.Trigger
                     class={buttonVariants({
@@ -392,19 +392,19 @@
     <section class="rounded-lg bg-white p-4 ring-1 ring-zinc-200">
         <form
             method="POST"
-            action="?/updateDevUrl"
+            action="?/updateBaseUrl"
             class="grid gap-3 lg:grid-cols-[1fr_auto]"
         >
             <div>
                 <label
-                    for="devUrl"
+                    for="baseUrl"
                     class="mb-1 block text-base/6 font-medium text-zinc-900 sm:text-sm/6"
-                    >Dev URL</label
+                    >Base URL</label
                 >
                 <Input
-                    id="devUrl"
-                    name="devUrl"
-                    value={data.batch.devUrl}
+                    id="baseUrl"
+                    name="baseUrl"
+                    value={data.batch.baseUrl}
                     placeholder="https://www.example.test"
                 />
             </div>
@@ -414,7 +414,7 @@
         </form>
     </section>
 
-    {#if validDevUrl}
+    {#if validBaseUrl}
         <section class="mt-6">
             <div class="mb-3 flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
                 <div>
@@ -610,9 +610,9 @@
                                         </td>
                                         <td class="py-3 pl-4 align-top">
                                             <div class="flex justify-end gap-2">
-                                                {#if url.devRedirectUrl}
+                                                {#if url.baseRedirectUrl}
                                                     <a
-                                                        href={url.devRedirectUrl}
+                                                        href={url.baseRedirectUrl}
                                                         target="_blank"
                                                         rel="noreferrer"
                                                         class={buttonVariants({
@@ -698,9 +698,9 @@
                                             ).value,
                                         )}
                                 />
-                                {#if url.devRedirectUrl}
+                                {#if url.baseRedirectUrl}
                                     <a
-                                        href={url.devRedirectUrl}
+                                        href={url.baseRedirectUrl}
                                         target="_blank"
                                         rel="noreferrer"
                                         class="mt-2 inline-flex items-center gap-1 text-base/7 font-medium text-primary sm:text-sm/6"
@@ -802,7 +802,7 @@
         <div
             class="mt-4 rounded-lg bg-sky-50 px-4 py-3 text-base/7 text-sky-950 ring-1 ring-sky-200 sm:text-sm/6"
         >
-            Enter a valid dev URL before adding URLs.
+            Enter a valid base URL before adding URLs.
         </div>
     {/if}
 
@@ -821,7 +821,7 @@
                         Archive batch?
                     </AlertDialog.Title>
                     <AlertDialog.Description class="text-zinc-600">
-                        This will hide {data.batch.devUrl ||
+                        This will hide {data.batch.baseUrl ||
                             "this redirect batch"} from your batches list. You can
                         no longer access it from the app after archiving.
                     </AlertDialog.Description>

--- a/src/routes/(app)/dashboard/+page.server.ts
+++ b/src/routes/(app)/dashboard/+page.server.ts
@@ -13,7 +13,7 @@ export async function load({ locals }) {
     const rows = await db
         .select({
             id: batches.id,
-            devUrl: batches.devUrl,
+            baseUrl: batches.baseUrl,
             createdAt: batches.createdAt,
             screenshotUpdatedAt: batches.screenshotUpdatedAt,
             urlCount: count(urls.id),
@@ -28,11 +28,11 @@ export async function load({ locals }) {
             and(
                 eq(batches.userId, locals.user.id),
                 isNull(batches.deletedAt),
-                sql`${batches.devUrl} <> ''`,
+                sql`${batches.baseUrl} <> ''`,
             ),
         )
         .groupBy(batches.id)
-        .orderBy(batches.devUrl);
+        .orderBy(batches.baseUrl);
 
     return { batches: rows };
 }
@@ -40,26 +40,26 @@ export async function load({ locals }) {
 export const actions = {
     create: async ({ locals, request }) => {
         if (!locals.user) {
-            return fail(401, { devUrl: "", message: "You must be signed in." });
+            return fail(401, { baseUrl: "", message: "You must be signed in." });
         }
 
         const formData = await request.formData();
-        const devUrl = String(formData.get("devUrl") ?? "").trim();
+        const baseUrl = String(formData.get("baseUrl") ?? "").trim();
 
-        if (!isValidHttpUrl(devUrl)) {
+        if (!isValidHttpUrl(baseUrl)) {
             return fail(400, {
-                devUrl,
-                message: "Enter a valid dev URL including http:// or https://.",
+                baseUrl,
+                message: "Enter a valid base URL including http:// or https://.",
             });
         }
 
         const [batch] = await db
             .insert(batches)
-            .values({ userId: locals.user.id, devUrl })
+            .values({ userId: locals.user.id, baseUrl })
             .returning({ id: batches.id });
 
         try {
-            await captureScreenshot(batch.id, devUrl);
+            await captureScreenshot(batch.id, baseUrl);
         } catch (error) {
             // Best effort — the batch is created regardless; the user can
             // retry capture with the refresh button.
@@ -91,12 +91,12 @@ export const actions = {
         if (!batch) {
             return fail(404, { message: "Batch not found." });
         }
-        if (!batch.devUrl) {
-            return fail(400, { message: "Set a dev URL first." });
+        if (!batch.baseUrl) {
+            return fail(400, { message: "Set a base URL first." });
         }
 
         try {
-            await captureScreenshot(batch.id, batch.devUrl);
+            await captureScreenshot(batch.id, batch.baseUrl);
         } catch (error) {
             console.error("[screenshot] capture failed on refresh", error);
             return fail(500, {

--- a/src/routes/(app)/dashboard/+page.svelte
+++ b/src/routes/(app)/dashboard/+page.svelte
@@ -40,13 +40,13 @@
         const needle = query.trim().toLowerCase();
         const matches = needle
             ? data.batches.filter((batch) =>
-                  batch.devUrl.toLowerCase().includes(needle),
+                  batch.baseUrl.toLowerCase().includes(needle),
               )
             : [...data.batches];
 
         return matches.sort((a, b) => {
             if (sort === "name")
-                return urlSortKey(a.devUrl).localeCompare(urlSortKey(b.devUrl));
+                return urlSortKey(a.baseUrl).localeCompare(urlSortKey(b.baseUrl));
             if (sort === "needs-work")
                 return b.remainingCount - a.remainingCount;
             return (
@@ -182,12 +182,12 @@
                                 <div class="relative">
                                     <a
                                         href={`/batch/${batch.id}`}
-                                        aria-label={`Manage ${batch.devUrl}`}
+                                        aria-label={`Manage ${batch.baseUrl}`}
                                     >
                                         {#if screenshotUrl(batch)}
                                             <img
                                                 src={screenshotUrl(batch)}
-                                                alt={`${batch.devUrl} screenshot`}
+                                                alt={`${batch.baseUrl} screenshot`}
                                                 class="aspect-video w-full bg-zinc-200 object-cover transition group-hover:opacity-90"
                                                 loading="lazy"
                                             />
@@ -235,7 +235,7 @@
                                             href={`/batch/${batch.id}`}
                                             class="block truncate text-base/6 font-semibold text-teal-800 hover:text-teal-900"
                                         >
-                                            {batch.devUrl}
+                                            {batch.baseUrl}
                                         </a>
                                         <div
                                             class="flex flex-wrap items-center gap-2"
@@ -307,7 +307,7 @@
                                             Manage
                                         </a>
                                         <a
-                                            href={batch.devUrl}
+                                            href={batch.baseUrl}
                                             target="_blank"
                                             rel="noreferrer"
                                             class="inline-flex items-center gap-1.5 rounded-md px-3 py-2 text-base/6 font-medium text-zinc-700 hover:bg-zinc-100 sm:py-1.5 sm:text-sm/6"
@@ -370,9 +370,9 @@
         <Sheet.Header>
             <Sheet.Title>New redirect batch</Sheet.Title>
             <Sheet.Description>
-                Enter the Dev URL — the site where you're actively working on
-                the redirects. You'll add the redirects to check after creating
-                the batch.
+                Enter the Base URL — the site you're checking the redirects
+                against, whether that's a dev, staging, or live site. You'll add
+                the redirects to check after creating the batch.
             </Sheet.Description>
         </Sheet.Header>
 
@@ -390,23 +390,23 @@
         >
             <div class="space-y-1.5">
                 <label
-                    for="new-batch-dev-url"
+                    for="new-batch-base-url"
                     class="block text-base/6 font-medium text-zinc-900 sm:text-sm/6"
                 >
-                    Dev URL
+                    Base URL
                 </label>
                 <Input
-                    id="new-batch-dev-url"
-                    name="devUrl"
+                    id="new-batch-base-url"
+                    name="baseUrl"
                     type="url"
-                    value={form?.devUrl ?? ""}
+                    value={form?.baseUrl ?? ""}
                     placeholder="https://www.example.test"
                     autocomplete="off"
                     required
                 />
                 <p class="text-sm/6 text-zinc-500">
-                    The staging or development site where you're actively
-                    working on the redirects.
+                    The site you're checking the redirects against — a dev,
+                    staging, or live site.
                 </p>
                 {#if form?.message}
                     <p class="text-sm/6 text-red-600">

--- a/src/routes/api/urls/[id]/+server.ts
+++ b/src/routes/api/urls/[id]/+server.ts
@@ -1,4 +1,4 @@
-import { getDevRedirectUrl, getDevUrl } from "$lib/server/redirects";
+import { getBaseRedirectUrl, getBaseUrl } from "$lib/server/redirects";
 import { db } from "$lib/server/db";
 import { batches, urls } from "$lib/server/schema";
 import { error, json } from "@sveltejs/kit";
@@ -52,8 +52,8 @@ export async function PATCH({ locals, params, request }) {
 
     return json({
         ...updated,
-        devUrl: getDevUrl(batch, updated),
-        devRedirectUrl: getDevRedirectUrl(batch, updated),
+        baseUrl: getBaseUrl(batch, updated),
+        baseRedirectUrl: getBaseRedirectUrl(batch, updated),
     });
 }
 

--- a/src/routes/api/urls/[id]/check/+server.ts
+++ b/src/routes/api/urls/[id]/check/+server.ts
@@ -1,4 +1,4 @@
-import { checkUrl, getDevRedirectUrl, getDevUrl, isValidHttpUrl } from "$lib/server/redirects";
+import { checkUrl, getBaseRedirectUrl, getBaseUrl, isValidHttpUrl } from "$lib/server/redirects";
 import { db } from "$lib/server/db";
 import { batches, urls } from "$lib/server/schema";
 import { error, json } from "@sveltejs/kit";
@@ -28,11 +28,11 @@ export async function POST({ locals, params }) {
         throw error(404, "URL not found");
     }
 
-    if (!isValidHttpUrl(row[0].batch.devUrl)) {
-        throw error(422, "Batch dev URL is invalid");
+    if (!isValidHttpUrl(row[0].batch.baseUrl)) {
+        throw error(422, "Batch base URL is invalid");
     }
 
-    const response = await checkUrl(getDevUrl(row[0].batch, row[0].url));
+    const response = await checkUrl(getBaseUrl(row[0].batch, row[0].url));
     const [updated] = await db
         .update(urls)
         .set({
@@ -45,7 +45,7 @@ export async function POST({ locals, params }) {
 
     return json({
         ...updated,
-        devUrl: getDevUrl(row[0].batch, updated),
-        devRedirectUrl: getDevRedirectUrl(row[0].batch, updated),
+        baseUrl: getBaseUrl(row[0].batch, updated),
+        baseRedirectUrl: getBaseRedirectUrl(row[0].batch, updated),
     });
 }


### PR DESCRIPTION
The field was always the base site the redirects are checked against,
which is often the live/production site rather than a dev environment,
so "Dev URL" was misleading.

- Rename schema column dev_url -> base_url with a rename migration
  (preserves existing data)
- Rename helpers getDevUrl/getDevRedirectUrl -> getBaseUrl/getBaseRedirectUrl
- Rename form field, action (updateDevUrl -> updateBaseUrl), and API
  response keys (devUrl/devRedirectUrl -> baseUrl/baseRedirectUrl)
- Update UI labels, copy, and error messages to "Base URL"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated deployment guide to clarify that screenshots are captured when the base URL is set rather than the dev URL.
  * Updated batch creation instructions to reference base URL configuration.

* **Refactor**
  * Renamed "Dev URL" to "Base URL" across all batch management and URL configuration interfaces for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->