### PR TITLE
Allow uploading screenshots to override generated previews

### DIFF
--- a/src/lib/server/screenshots.ts
+++ b/src/lib/server/screenshots.ts
@@ -17,6 +17,16 @@ const LOAD_SETTLE_TIMEOUT = 3_000;
 const FONT_SETTLE_TIMEOUT = 2_000;
 const FINAL_SETTLE_MS = 1_000;
 const JPEG_QUALITY = 72;
+// Uploaded screenshots are normalized to the same dimensions/format as captured
+// ones so the serving endpoint and storage path stay identical.
+export const MAX_UPLOAD_BYTES = 10 * 1024 * 1024;
+export const ACCEPTED_UPLOAD_TYPES = [
+    "image/jpeg",
+    "image/png",
+    "image/webp",
+    "image/gif",
+    "image/avif",
+];
 const BLOCKED_VIDEO_HOSTS = [
     "youtube.com",
     "youtube-nocookie.com",
@@ -231,4 +241,60 @@ export async function captureScreenshot(batchId: number, baseUrl: string): Promi
     }
 
     throw lastError;
+}
+
+// Store a user-uploaded image as the batch's screenshot, overriding whatever was
+// generated. The upload is re-encoded to a JPEG at the standard viewport width
+// (reusing the capture browser) so it lives at the same path and is served by the
+// same endpoint as a generated screenshot. Throws on an undecodable image.
+export async function storeUploadedScreenshot(
+    batchId: number,
+    bytes: Uint8Array,
+    mimeType: string,
+): Promise<void> {
+    if (bytes.byteLength > MAX_UPLOAD_BYTES) {
+        throw new Error("Image is too large.");
+    }
+
+    const browser = await getBrowser();
+    const context = await browser.newContext({ viewport: VIEWPORT });
+
+    try {
+        const page = await context.newPage();
+        const dataUrl = `data:${mimeType};base64,${Buffer.from(bytes).toString("base64")}`;
+
+        // Decode and re-encode in the page: Chromium handles every accepted type
+        // and a canvas gives us a normalized JPEG without an image library.
+        const jpegBase64 = await page.evaluate(
+            async ({ src, quality, maxWidth }) => {
+                const img = new Image();
+                img.src = src;
+                await img.decode();
+
+                const scale = Math.min(1, maxWidth / img.naturalWidth);
+                const canvas = document.createElement("canvas");
+                canvas.width = Math.max(1, Math.round(img.naturalWidth * scale));
+                canvas.height = Math.max(1, Math.round(img.naturalHeight * scale));
+
+                const ctx = canvas.getContext("2d");
+                if (!ctx) throw new Error("Canvas 2D context unavailable.");
+                ctx.drawImage(img, 0, 0, canvas.width, canvas.height);
+
+                return canvas.toDataURL("image/jpeg", quality).split(",")[1] ?? "";
+            },
+            { src: dataUrl, quality: JPEG_QUALITY / 100, maxWidth: VIEWPORT.width },
+        );
+
+        if (!jpegBase64) throw new Error("Image could not be decoded.");
+
+        await mkdir(STORAGE_DIR, { recursive: true });
+        await writeFile(screenshotFilePath(batchId), Buffer.from(jpegBase64, "base64"));
+
+        await db
+            .update(batches)
+            .set({ screenshotUpdatedAt: new Date() })
+            .where(eq(batches.id, batchId));
+    } finally {
+        await context.close();
+    }
 }

--- a/src/routes/(app)/dashboard/+page.server.ts
+++ b/src/routes/(app)/dashboard/+page.server.ts
@@ -1,5 +1,10 @@
 import { db } from "$lib/server/db";
-import { captureScreenshot } from "$lib/server/screenshots";
+import {
+    ACCEPTED_UPLOAD_TYPES,
+    MAX_UPLOAD_BYTES,
+    captureScreenshot,
+    storeUploadedScreenshot,
+} from "$lib/server/screenshots";
 import { batches, urls } from "$lib/server/schema";
 import { isValidHttpUrl } from "$lib/server/redirects";
 import { fail, redirect } from "@sveltejs/kit";
@@ -105,5 +110,54 @@ export const actions = {
         }
 
         return { success: "Screenshot refreshed." };
+    },
+
+    uploadScreenshot: async ({ locals, request }) => {
+        if (!locals.user) {
+            return fail(401, { message: "You must be signed in." });
+        }
+
+        const formData = await request.formData();
+        const batchId = Number(formData.get("batchId"));
+        if (!Number.isInteger(batchId)) {
+            return fail(400, { message: "Invalid batch." });
+        }
+
+        const file = formData.get("screenshot");
+        if (!(file instanceof File) || file.size === 0) {
+            return fail(400, { message: "Choose an image to upload." });
+        }
+        if (!ACCEPTED_UPLOAD_TYPES.includes(file.type)) {
+            return fail(400, {
+                message: "Upload a PNG, JPEG, WebP, GIF, or AVIF image.",
+            });
+        }
+        if (file.size > MAX_UPLOAD_BYTES) {
+            return fail(400, { message: "Image must be 10 MB or smaller." });
+        }
+
+        const batch = await db.query.batches.findFirst({
+            where: and(
+                eq(batches.id, batchId),
+                eq(batches.userId, locals.user.id),
+                isNull(batches.deletedAt),
+            ),
+        });
+
+        if (!batch) {
+            return fail(404, { message: "Batch not found." });
+        }
+
+        try {
+            const bytes = new Uint8Array(await file.arrayBuffer());
+            await storeUploadedScreenshot(batch.id, bytes, file.type);
+        } catch (error) {
+            console.error("[screenshot] upload failed", error);
+            return fail(500, {
+                message: `Could not save screenshot: ${error instanceof Error ? error.message : String(error)}`,
+            });
+        }
+
+        return { success: "Screenshot updated." };
     },
 };

--- a/src/routes/(app)/dashboard/+page.svelte
+++ b/src/routes/(app)/dashboard/+page.svelte
@@ -9,9 +9,11 @@
         Check,
         ExternalLink,
         FolderPlus,
+        Loader2,
         Plus,
         RotateCw,
         Search,
+        Upload,
     } from "lucide-svelte";
 
     let { data, form } = $props();
@@ -20,6 +22,7 @@
     let creating = $state(false);
 
     let refreshing = $state<Record<number, boolean>>({});
+    let uploading = $state<Record<number, boolean>>({});
 
     let query = $state("");
     let sort = $state<"recent" | "name" | "needs-work">("recent");
@@ -68,6 +71,19 @@
 
 <Sheet.Root bind:open={createOpen}>
     <main class="mx-auto max-w-7xl px-4 py-6 sm:px-6 lg:px-8">
+        {#if form?.success}
+            <div
+                class="mb-4 rounded-md bg-teal-50 px-4 py-3 text-sm/6 text-teal-800 ring-1 ring-teal-200"
+            >
+                {form.success}
+            </div>
+        {:else if form?.message}
+            <div
+                class="mb-4 rounded-md bg-red-50 px-4 py-3 text-sm/6 text-red-700 ring-1 ring-red-200"
+            >
+                {form.message}
+            </div>
+        {/if}
         <div
             class="mb-6 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between"
         >
@@ -199,35 +215,94 @@
                                             </div>
                                         {/if}
                                     </a>
-                                    <form
-                                        method="POST"
-                                        action="?/refreshScreenshot"
-                                        class="absolute top-2 right-2"
-                                        use:enhance={() => {
-                                            refreshing[batch.id] = true;
-                                            return async ({ update }) => {
-                                                await update();
-                                                refreshing[batch.id] = false;
-                                            };
-                                        }}
+                                    <div
+                                        class="absolute top-2 right-2 flex gap-1"
                                     >
-                                        <input
-                                            type="hidden"
-                                            name="batchId"
-                                            value={batch.id}
-                                        />
-                                        <button
-                                            type="submit"
-                                            disabled={refreshing[batch.id]}
-                                            title="Refresh screenshot"
-                                            aria-label="Refresh screenshot"
-                                            class="rounded-md bg-white/90 p-1.5 text-zinc-700 ring-1 ring-zinc-200 backdrop-blur hover:bg-white disabled:opacity-60"
+                                        <form
+                                            method="POST"
+                                            action="?/uploadScreenshot"
+                                            enctype="multipart/form-data"
+                                            class="contents"
+                                            use:enhance={() => {
+                                                uploading[batch.id] = true;
+                                                return async ({ update }) => {
+                                                    await update({
+                                                        reset: true,
+                                                    });
+                                                    uploading[batch.id] = false;
+                                                };
+                                            }}
                                         >
-                                            <RotateCw
-                                                class={`size-4 ${refreshing[batch.id] ? "animate-spin" : ""}`}
+                                            <input
+                                                type="hidden"
+                                                name="batchId"
+                                                value={batch.id}
                                             />
-                                        </button>
-                                    </form>
+                                            <label
+                                                title="Upload screenshot"
+                                                aria-label="Upload screenshot"
+                                                class="cursor-pointer rounded-md bg-white/90 p-1.5 text-zinc-700 ring-1 ring-zinc-200 backdrop-blur hover:bg-white {uploading[
+                                                    batch.id
+                                                ]
+                                                    ? 'pointer-events-none opacity-60'
+                                                    : ''}"
+                                            >
+                                                {#if uploading[batch.id]}
+                                                    <Loader2
+                                                        class="size-4 animate-spin"
+                                                    />
+                                                {:else}
+                                                    <Upload class="size-4" />
+                                                {/if}
+                                                <input
+                                                    type="file"
+                                                    name="screenshot"
+                                                    accept="image/png,image/jpeg,image/webp,image/gif,image/avif"
+                                                    class="sr-only"
+                                                    disabled={uploading[
+                                                        batch.id
+                                                    ]}
+                                                    onchange={(event) => {
+                                                        if (
+                                                            event.currentTarget
+                                                                .files?.length
+                                                        ) {
+                                                            event.currentTarget.form?.requestSubmit();
+                                                        }
+                                                    }}
+                                                />
+                                            </label>
+                                        </form>
+                                        <form
+                                            method="POST"
+                                            action="?/refreshScreenshot"
+                                            class="contents"
+                                            use:enhance={() => {
+                                                refreshing[batch.id] = true;
+                                                return async ({ update }) => {
+                                                    await update();
+                                                    refreshing[batch.id] = false;
+                                                };
+                                            }}
+                                        >
+                                            <input
+                                                type="hidden"
+                                                name="batchId"
+                                                value={batch.id}
+                                            />
+                                            <button
+                                                type="submit"
+                                                disabled={refreshing[batch.id]}
+                                                title="Refresh screenshot"
+                                                aria-label="Refresh screenshot"
+                                                class="rounded-md bg-white/90 p-1.5 text-zinc-700 ring-1 ring-zinc-200 backdrop-blur hover:bg-white disabled:opacity-60"
+                                            >
+                                                <RotateCw
+                                                    class={`size-4 ${refreshing[batch.id] ? "animate-spin" : ""}`}
+                                                />
+                                            </button>
+                                        </form>
+                                    </div>
                                 </div>
                                 <div class="space-y-4 p-4">
                                     <div class="space-y-2">


### PR DESCRIPTION
## What changed

Adds the ability to upload a custom screenshot for a batch on the `/dashboard` page, overriding the auto-generated preview.

- Each batch card gains an **upload** button next to the existing refresh button on the screenshot thumbnail. Selecting an image auto-submits and shows a spinner while it saves.
- New `uploadScreenshot` form action validates auth, batch ownership, image type (PNG/JPEG/WebP/GIF/AVIF), and a 10 MB size limit.
- `storeUploadedScreenshot()` re-encodes the upload to a JPEG at the standard capture width by reusing the existing Chromium instance (canvas re-encode — no new image-processing dependency). The result is written to the same path and served by the same `/api/screenshot/[id]` endpoint as generated screenshots, and bumps `screenshotUpdatedAt` to cache-bust the thumbnail.
- Adds a success/error feedback banner on the dashboard.

## Why

Generated screenshots can fail or look wrong for some sites; this lets users supply their own image instead.

## How to test

1. Go to `/dashboard` and create or open a batch.
2. Click the upload (↑) icon on a batch card's thumbnail and choose an image.
3. Confirm the thumbnail updates to the uploaded image and a success banner appears.
4. Try an oversized (>10 MB) or non-image file and confirm a validation error banner appears.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Upload custom screenshots from the dashboard to override auto-generated captures
  * Real-time upload progress indicators with clear success/error messaging
  * Support for common image formats with file size safeguards
  * Improved batch action controls for more intuitive screenshot management

<!-- end of auto-generated comment: release notes by coderabbit.ai -->