### PR TITLE
ci: give Dokploy a pull-only GHCR token

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -42,6 +42,20 @@ jobs:
       contents: read
       packages: write
     steps:
+      # Fails before the build rather than after it. GHCR_PULL_TOKEN is what
+      # Dokploy stores to pull this image; an unset secret interpolates to an
+      # empty string, which would hand Dokploy blank credentials and leave it
+      # unable to pull. There is deliberately no fallback to GHCR_TOKEN, because
+      # that would silently restore the push-capable token this separates out.
+      - name: Require the GHCR pull token
+        env:
+          GHCR_PULL_TOKEN: ${{ secrets.GHCR_PULL_TOKEN }}
+        run: |
+          if [ -z "$GHCR_PULL_TOKEN" ]; then
+            echo "::error::GHCR_PULL_TOKEN is not set. Dokploy needs a read:packages token to pull this image. Create one and add it as a repository secret; do not reuse GHCR_TOKEN, which can push."
+            exit 1
+          fi
+
       - name: Checkout
         uses: actions/checkout@v5
 
@@ -90,7 +104,9 @@ jobs:
           DOKPLOY_URL: ${{ secrets.DOKPLOY_URL }}
           DOKPLOY_API_KEY: ${{ secrets.DOKPLOY_API_KEY }}
           DOKPLOY_APPLICATION_ID: ${{ secrets.DOKPLOY_APPLICATION_ID }}
-          GHCR_TOKEN: ${{ secrets.GHCR_TOKEN }}
+          # Pull-only. Dokploy stores this credential, so it must not be able to
+          # push to the package; GHCR_TOKEN stays scoped to the login above.
+          GHCR_PULL_TOKEN: ${{ secrets.GHCR_PULL_TOKEN }}
           IMAGE_REF: ${{ steps.meta.outputs.image }}:${{ github.sha }}
         run: |
           curl --fail --show-error --silent \
@@ -101,7 +117,7 @@ jobs:
             -d "$(jq -nc \
                   --arg id "$DOKPLOY_APPLICATION_ID" \
                   --arg image "$IMAGE_REF" \
-                  --arg pass "$GHCR_TOKEN" \
+                  --arg pass "$GHCR_PULL_TOKEN" \
                   '{applicationId:$id, dockerImage:$image, registryUrl:"ghcr.io", username:"michaelbonner", password:$pass}')"
 
           # Partial update — `env` is deliberately not sent, so the runtime

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -88,6 +88,36 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
+      # The non-empty check above cannot tell whether the token still WORKS. An
+      # expired or revoked one would sail past it, and then saveDockerProvider
+      # would replace Dokploy's working registry credentials with a dead value —
+      # leaving the app unable to pull anything, which is worse than a failed
+      # deploy. So prove the credential can read this exact image before it is
+      # stored anywhere.
+      #
+      # DOCKER_CONFIG points at a throwaway directory on purpose: the push login
+      # earlier in this job is still active, and without an isolated credential
+      # store `docker manifest inspect` would happily succeed on GHCR_TOKEN and
+      # tell us nothing about GHCR_PULL_TOKEN.
+      - name: Verify the pull token can actually read this image
+        env:
+          GHCR_PULL_TOKEN: ${{ secrets.GHCR_PULL_TOKEN }}
+          IMAGE_REF: ${{ steps.meta.outputs.image }}:${{ github.sha }}
+        run: |
+          set -euo pipefail
+          DOCKER_CONFIG="$(mktemp -d)"
+          export DOCKER_CONFIG
+          trap 'rm -rf "$DOCKER_CONFIG"' EXIT
+          if ! printf '%%s' "$GHCR_PULL_TOKEN" | docker login ghcr.io -u michaelbonner --password-stdin >/dev/null 2>&1; then
+            echo "::error::GHCR_PULL_TOKEN was rejected by ghcr.io. Not storing it on Dokploy, which would replace working registry credentials with an unusable one."
+            exit 1
+          fi
+          if ! docker manifest inspect "$IMAGE_REF" >/dev/null 2>&1; then
+            echo "::error::GHCR_PULL_TOKEN authenticated but cannot read $IMAGE_REF. It likely lacks read:packages or access to this package. Not storing it on Dokploy."
+            exit 1
+          fi
+          echo "GHCR_PULL_TOKEN can pull $IMAGE_REF"
+
       # Point the app at the exact image this run produced rather than :latest,
       # so a redeploy from the Dokploy UI replays this commit instead of
       # whatever happens to be tagged latest at that moment.

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -108,7 +108,7 @@ jobs:
           DOCKER_CONFIG="$(mktemp -d)"
           export DOCKER_CONFIG
           trap 'rm -rf "$DOCKER_CONFIG"' EXIT
-          if ! printf '%%s' "$GHCR_PULL_TOKEN" | docker login ghcr.io -u michaelbonner --password-stdin >/dev/null 2>&1; then
+          if ! printf '%s' "$GHCR_PULL_TOKEN" | docker login ghcr.io -u michaelbonner --password-stdin >/dev/null 2>&1; then
             echo "::error::GHCR_PULL_TOKEN was rejected by ghcr.io. Not storing it on Dokploy, which would replace working registry credentials with an unusable one."
             exit 1
           fi

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -111,7 +111,7 @@ jobs:
           DOCKER_CONFIG="$(mktemp -d)"
           export DOCKER_CONFIG
           trap 'rm -rf "$DOCKER_CONFIG"' EXIT
-          if ! printf '%%s' "$GHCR_PULL_TOKEN" | docker login ghcr.io -u michaelbonner --password-stdin >/dev/null 2>&1; then
+          if ! printf '%s' "$GHCR_PULL_TOKEN" | docker login ghcr.io -u michaelbonner --password-stdin >/dev/null 2>&1; then
             echo "::error::GHCR_PULL_TOKEN was rejected by ghcr.io. Not storing it on Dokploy, which would replace working registry credentials with an unusable one."
             exit 1
           fi

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -91,6 +91,36 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
+      # The non-empty check above cannot tell whether the token still WORKS. An
+      # expired or revoked one would sail past it, and then saveDockerProvider
+      # would replace Dokploy's working registry credentials with a dead value —
+      # leaving the app unable to pull anything, which is worse than a failed
+      # deploy. So prove the credential can read this exact image before it is
+      # stored anywhere.
+      #
+      # DOCKER_CONFIG points at a throwaway directory on purpose: the push login
+      # earlier in this job is still active, and without an isolated credential
+      # store `docker manifest inspect` would happily succeed on GHCR_TOKEN and
+      # tell us nothing about GHCR_PULL_TOKEN.
+      - name: Verify the pull token can actually read this image
+        env:
+          GHCR_PULL_TOKEN: ${{ secrets.GHCR_PULL_TOKEN }}
+          IMAGE_REF: ${{ steps.vars.outputs.image }}:pr-${{ github.event.number }}-${{ github.sha }}
+        run: |
+          set -euo pipefail
+          DOCKER_CONFIG="$(mktemp -d)"
+          export DOCKER_CONFIG
+          trap 'rm -rf "$DOCKER_CONFIG"' EXIT
+          if ! printf '%%s' "$GHCR_PULL_TOKEN" | docker login ghcr.io -u michaelbonner --password-stdin >/dev/null 2>&1; then
+            echo "::error::GHCR_PULL_TOKEN was rejected by ghcr.io. Not storing it on Dokploy, which would replace working registry credentials with an unusable one."
+            exit 1
+          fi
+          if ! docker manifest inspect "$IMAGE_REF" >/dev/null 2>&1; then
+            echo "::error::GHCR_PULL_TOKEN authenticated but cannot read $IMAGE_REF. It likely lacks read:packages or access to this package. Not storing it on Dokploy."
+            exit 1
+          fi
+          echo "GHCR_PULL_TOKEN can pull $IMAGE_REF"
+
       # Run the orchestration script from the BASE branch, not the PR, so a PR
       # cannot modify code that executes with DOKPLOY_API_KEY in scope.
       #

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -54,6 +54,15 @@ jobs:
       # Only the image ref: the preview host is the script's to decide, and the
       # PR comment reads it back from the deploy step's preview_url output.
       # Computing it a second time here would let the two drift.
+      - name: Require the GHCR pull token
+        env:
+          GHCR_PULL_TOKEN: ${{ secrets.GHCR_PULL_TOKEN }}
+        run: |
+          if [ -z "$GHCR_PULL_TOKEN" ]; then
+            echo "::error::GHCR_PULL_TOKEN is not set. Dokploy needs a read:packages token to pull preview images. Create one and add it as a repository secret; do not reuse GHCR_TOKEN, which can push."
+            exit 1
+          fi
+
       - name: Compute image name
         id: vars
         run: echo "image=$(echo "${IMAGE}" | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_OUTPUT"
@@ -120,7 +129,9 @@ jobs:
           DOKPLOY_PREVIEW_ENVIRONMENT_ID: ${{ env.DOKPLOY_PREVIEW_ENVIRONMENT_ID }}
           PREVIEW_HOST_SUFFIX: ${{ env.PREVIEW_HOST_SUFFIX }}
           GHCR_USERNAME: michaelbonner
-          GHCR_PASSWORD: ${{ secrets.GHCR_TOKEN }}
+          # Pull-only, for the same reason as production: this is stored on the
+          # per-PR Dokploy app so it can pull the preview image.
+          GHCR_PASSWORD: ${{ secrets.GHCR_PULL_TOKEN }}
           PR_NUMBER: ${{ github.event.number }}
           IMAGE: ${{ steps.vars.outputs.image }}:pr-${{ github.event.number }}-${{ github.sha }}
         run: node scripts/dokploy-preview.mjs deploy


### PR DESCRIPTION
Dokploy stored `GHCR_TOKEN`, which carries `write:packages`. A compromise of the
Dokploy host could therefore push images to any package the PAT owner can reach.
Before this migration Dokploy pulled source through its GitHub App and held no
GHCR credential at all, so this was an exposure the migration itself introduced
— raised in review on bootpack-digital#367 and deferred because it needed a
token only the owner could create.

### The split

| Credential | Used for | Scope |
| --- | --- | --- |
| `GHCR_TOKEN` | `docker/login` to **push** the built image | `write:packages` |
| `GHCR_PULL_TOKEN` | handed to Dokploy so it can **pull** | `read:packages` |

That applies to production (`application.saveDockerProvider`) and to previews,
where the same credential is stored on each per-PR app.

### Fails closed

Both workflows check `GHCR_PULL_TOKEN` before building. There is deliberately
no fallback to `GHCR_TOKEN`: a fallback would silently restore the push-capable
credential this exists to remove, and an unset secret interpolates to an empty
string, which would leave Dokploy holding blank registry credentials and unable
to pull at all.

The check runs before the image build and before any Dokploy call, so a missing
or expired token blocks new deploys without disturbing what is currently
serving.

### Verified

The token was checked before being wired in — `read:packages` and nothing else:

```
$ curl -sI -H "Authorization: token ***" https://api.github.com/user | grep x-oauth-scopes
x-oauth-scopes: read:packages
```

and it can read the private manifests Dokploy needs (`docker manifest inspect`
succeeds for all nine packages). `GHCR_PULL_TOKEN` is set on every repo in this
migration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deployment validation to detect missing or invalid container registry credentials before deployment.
  * Enhanced preview and production deployments to verify access to the exact container image being used.
  * Prevented invalid registry credentials from being saved in deployment configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->