### PR TITLE
Add a CLI for batch and redirect data

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,58 @@ Redirects Wizard is a SvelteKit app for building and checking redirect rules —
     bun run dev
     ```
 
+## CLI
+
+`scripts/redirects.ts` exposes the same batch and URL operations as the app, for
+scripting and for AI agents. It talks to Postgres directly — no dev server or
+sign-in needed — reading connection strings from `.env`.
+
+```sh
+./scripts/redirects.ts batches           # or: bun run cli batches
+./scripts/redirects.ts help              # full command and flag reference
+```
+
+| Command                         | Description                                              |
+| ------------------------------- | -------------------------------------------------------- |
+| `batches`                       | List batches with URL, unresolved, and untargeted counts |
+| `batch <id>`                    | Show a batch and its URLs                                |
+| `batch create <base-url>`       | Create a batch for a base URL                            |
+| `batch set-base-url <id> <url>` | Point a batch at a different base URL                    |
+| `batch check <id>`              | Re-request the batch's URLs and store their statuses     |
+| `batch redirects <id>`          | Print generated redirect rules                           |
+| `batch archive <id>`            | Archive (soft-delete) a batch                            |
+| `urls add <batch-id> [url...]`  | Add production URLs; reads stdin when none are given     |
+| `url <id>`                      | Show one URL with its redirect chain                     |
+| `url set-target <id> [target]`  | Set the redirect target; omit it to clear                |
+| `url check <id>`                | Re-request one URL and store the status                  |
+| `url delete <id>`               | Delete (soft-delete) a URL                               |
+| `users`                         | List accounts, for use with `--user`                     |
+
+Useful flags: `--json` for machine-readable output, `--filter unresolved`,
+`--format nginx`, `--limit`, `--no-check`, and `--concurrency`.
+
+Batches are scoped to one account. With a single account in the database no flag
+is needed; otherwise pass `--user <email>` or set `REDIRECTS_USER`.
+
+`--db local` (the default), `--db preview`, and `--db production` select
+`DATABASE_URL`, `PREVIEW_DATABASE_URL`, and `PRODUCTION_DATABASE_URL`
+respectively. Reads work anywhere; commands that write to production also
+require `--yes`.
+
+Unlike the app, `batch create` does not capture a screenshot — use the
+dashboard's refresh button for that.
+
+A typical migration pass:
+
+```sh
+./scripts/redirects.ts batch create https://staging.example.com
+cat old-urls.txt | ./scripts/redirects.ts urls add 12
+./scripts/redirects.ts batch 12 --filter untargeted
+./scripts/redirects.ts url set-target 480 /new-page
+./scripts/redirects.ts batch redirects 12 --format nginx
+./scripts/redirects.ts batch check 12 --filter unresolved
+```
+
 ## Deploying
 
 The app uses `svelte-adapter-bun` for SvelteKit production builds.

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
         "preview": "vite preview",
         "start": "bun db:migrate && bun ./build/index.js",
         "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
+        "cli": "bun scripts/redirects.ts",
         "db:generate": "drizzle-kit generate",
         "db:migrate": "drizzle-kit migrate",
         "db:copy-production-to-preview": "bun scripts/copy-production-db-to-preview.ts",

--- a/scripts/cli/batches.ts
+++ b/scripts/cli/batches.ts
@@ -1,0 +1,322 @@
+import { and, asc, count, eq, isNotNull, isNull, sql } from "drizzle-orm";
+import { getRedirectFormats, isValidHttpUrl } from "../../src/lib/server/redirects";
+import { batches, urls } from "../../src/lib/server/schema";
+import { CliError, getOwnedBatch } from "./context";
+import type { Context, Url } from "./context";
+import {
+    date,
+    pluralize,
+    print,
+    printFields,
+    printJson,
+    printTable,
+    statusCode,
+    text,
+    yesNo,
+} from "./output";
+import { mapWithConcurrency, recheckUrl, serializeUrl, urlColumns, urlRow } from "./urls";
+
+/** Which URLs of a batch to show. */
+export const urlFilters = ["all", "unresolved", "resolved", "untargeted"] as const;
+
+export type UrlFilter = (typeof urlFilters)[number];
+
+export function parseUrlFilter(value: string): UrlFilter {
+    if ((urlFilters as readonly string[]).includes(value)) return value as UrlFilter;
+    throw new CliError(
+        `Unknown --filter "${value}". Expected one of: ${urlFilters.join(", ")}.`,
+        2,
+    );
+}
+
+function matchesFilter(url: Url, filter: UrlFilter) {
+    switch (filter) {
+        case "unresolved":
+            return !url.addressed;
+        case "resolved":
+            return url.addressed;
+        case "untargeted":
+            return !url.addressed && !url.redirectTo;
+        case "all":
+            return true;
+    }
+}
+
+export async function listBatches(context: Context) {
+    const owner = await context.requireUser();
+    const rows = await context.db
+        .select({
+            id: batches.id,
+            baseUrl: batches.baseUrl,
+            createdAt: batches.createdAt,
+            urlCount: count(urls.id),
+            unresolvedCount:
+                sql<number>`count(${urls.id}) filter (where ${urls.addressed} = false)`.mapWith(
+                    Number,
+                ),
+            untargetedCount:
+                sql<number>`count(${urls.id}) filter (where ${urls.addressed} = false and ${urls.redirectTo} is null)`.mapWith(
+                    Number,
+                ),
+        })
+        .from(batches)
+        .leftJoin(urls, and(eq(urls.batchId, batches.id), isNull(urls.deletedAt)))
+        .where(and(eq(batches.userId, owner.id), isNull(batches.deletedAt)))
+        .groupBy(batches.id)
+        .orderBy(batches.baseUrl);
+
+    if (context.json) {
+        printJson({ user: owner.email, batches: rows });
+        return;
+    }
+
+    printTable(
+        ["ID", "BASE URL", "URLS", "UNRESOLVED", "UNTARGETED", "CREATED"],
+        rows.map((row) => [
+            String(row.id),
+            text(row.baseUrl),
+            String(row.urlCount),
+            String(row.unresolvedCount),
+            String(row.untargetedCount),
+            date(row.createdAt),
+        ]),
+        `No batches for ${owner.email}.`,
+    );
+}
+
+export type ShowBatchOptions = {
+    batchId: number;
+    filter: UrlFilter;
+    limit?: number;
+};
+
+export async function showBatch(context: Context, options: ShowBatchOptions) {
+    const batch = await getOwnedBatch(context, options.batchId);
+    const allUrls = await context.db.query.urls.findMany({
+        where: and(eq(urls.batchId, batch.id), isNull(urls.deletedAt)),
+        orderBy: [asc(urls.addressed), asc(urls.url)],
+    });
+
+    const matching = allUrls.filter((url) => matchesFilter(url, options.filter));
+    const shown = options.limit === undefined ? matching : matching.slice(0, options.limit);
+    const unresolved = allUrls.filter((url) => !url.addressed);
+
+    if (context.json) {
+        printJson({
+            batch,
+            counts: {
+                total: allUrls.length,
+                unresolved: unresolved.length,
+                untargeted: unresolved.filter((url) => !url.redirectTo).length,
+                matchingFilter: matching.length,
+            },
+            urls: shown.map((url) => serializeUrl(batch, url)),
+        });
+        return;
+    }
+
+    printFields([
+        ["Batch", String(batch.id)],
+        ["Base URL", text(batch.baseUrl)],
+        ["URLs", String(allUrls.length)],
+        ["Unresolved", String(unresolved.length)],
+        ["Untargeted", String(unresolved.filter((url) => !url.redirectTo).length)],
+        ["Created", date(batch.createdAt)],
+    ]);
+    print();
+    printTable(urlColumns, shown.map(urlRow), `No URLs match --filter ${options.filter}.`);
+
+    if (shown.length < matching.length) {
+        print();
+        print(`Showing ${shown.length} of ${matching.length} matching URLs (--limit).`);
+    }
+}
+
+export async function createBatch(context: Context, baseUrl: string) {
+    context.requireWritable("create a batch");
+
+    if (!isValidHttpUrl(baseUrl)) {
+        throw new CliError("Enter a valid base URL including http:// or https://.");
+    }
+
+    const owner = await context.requireUser();
+    const [batch] = await context.db
+        .insert(batches)
+        .values({ userId: owner.id, baseUrl })
+        .returning();
+
+    if (context.json) {
+        printJson({ batch });
+        return;
+    }
+
+    print(`Created batch ${batch.id} for ${baseUrl}.`);
+}
+
+export async function setBaseUrl(context: Context, batchId: number, baseUrl: string) {
+    context.requireWritable("change a base URL");
+
+    if (!isValidHttpUrl(baseUrl)) {
+        throw new CliError("Enter a valid base URL including http:// or https://.");
+    }
+
+    const batch = await getOwnedBatch(context, batchId);
+    const [updated] = await context.db
+        .update(batches)
+        .set({ baseUrl, updatedAt: new Date() })
+        .where(eq(batches.id, batch.id))
+        .returning();
+
+    if (context.json) {
+        printJson({ batch: updated });
+        return;
+    }
+
+    print(`Batch ${updated.id} base URL set to ${updated.baseUrl}.`);
+    print("Re-check the URLs with `batch check` to refresh their statuses.");
+}
+
+export type CheckBatchOptions = {
+    batchId: number;
+    filter: UrlFilter;
+    concurrency: number;
+};
+
+export async function checkBatch(context: Context, options: CheckBatchOptions) {
+    context.requireWritable("check a batch");
+    const batch = await getOwnedBatch(context, options.batchId);
+
+    if (!isValidHttpUrl(batch.baseUrl)) {
+        throw new CliError(
+            `Batch ${batch.id} has no valid base URL — set one with \`batch set-base-url ${batch.id} <url>\`.`,
+        );
+    }
+
+    const pending = (
+        await context.db.query.urls.findMany({
+            where: and(eq(urls.batchId, batch.id), isNull(urls.deletedAt)),
+            orderBy: [asc(urls.url)],
+        })
+    ).filter((url) => matchesFilter(url, options.filter));
+
+    if (!pending.length) {
+        throw new CliError(`No URLs in batch ${batch.id} match --filter ${options.filter}.`);
+    }
+
+    const before = new Map(pending.map((url) => [url.id, url.addressed]));
+    const checked = await mapWithConcurrency(pending, options.concurrency, (url) =>
+        recheckUrl(context, batch, url),
+    );
+    const resolved = checked.filter((url) => url.addressed && !before.get(url.id));
+
+    if (context.json) {
+        printJson({
+            batchId: batch.id,
+            checked: checked.length,
+            newlyResolved: resolved.map((url) => url.id),
+            urls: checked.map((url) => serializeUrl(batch, url)),
+        });
+        return;
+    }
+
+    printTable(
+        ["ID", "STATUS", "RESOLVED", "URL", "TARGET"],
+        checked.map((url) => [
+            String(url.id),
+            statusCode(url),
+            yesNo(url.addressed),
+            url.url,
+            text(url.redirectTo),
+        ]),
+    );
+    print();
+    print(
+        `Checked ${pluralize(checked.length, "URL")}; ${checked.filter((url) => !url.addressed).length} still unresolved, ${resolved.length} newly resolved.`,
+    );
+}
+
+export type BatchRedirectsOptions = {
+    batchId: number;
+    /** A format id from getRedirectFormats, or "all". */
+    format: string;
+};
+
+export async function batchRedirects(context: Context, options: BatchRedirectsOptions) {
+    const batch = await getOwnedBatch(context, options.batchId);
+
+    // Mirrors /api/batches/[id]/redirects: rules exist only for URLs that still
+    // need a redirect and have a target set.
+    const pending = await context.db.query.urls.findMany({
+        where: and(
+            eq(urls.batchId, batch.id),
+            eq(urls.addressed, false),
+            isNotNull(urls.redirectTo),
+            isNull(urls.deletedAt),
+        ),
+    });
+
+    const formats = getRedirectFormats(batch, pending);
+    const requested =
+        options.format === "all"
+            ? formats
+            : formats.filter((format) => format.id === options.format);
+
+    if (!requested.length) {
+        throw new CliError(
+            `Unknown --format "${options.format}". Expected all or one of: ${formats
+                .map((format) => format.id)
+                .join(", ")}.`,
+            2,
+        );
+    }
+
+    if (context.json) {
+        printJson({ batchId: batch.id, count: pending.length, formats: requested });
+        return;
+    }
+
+    if (!pending.length) {
+        print(`No unresolved URLs with a redirect target in batch ${batch.id}.`);
+        return;
+    }
+
+    requested.forEach((format, index) => {
+        if (index > 0) print();
+        if (requested.length > 1) print(`# ${format.label} (${format.filename})`);
+        print(format.body);
+    });
+}
+
+export async function archiveBatch(context: Context, batchId: number) {
+    context.requireWritable("archive a batch");
+    const batch = await getOwnedBatch(context, batchId);
+    await context.db
+        .update(batches)
+        .set({ deletedAt: new Date(), updatedAt: new Date() })
+        .where(eq(batches.id, batch.id));
+
+    if (context.json) {
+        printJson({ id: batch.id, archived: true });
+        return;
+    }
+
+    print(`Archived batch ${batch.id} (${text(batch.baseUrl)}).`);
+}
+
+export async function listUsers(context: Context) {
+    const rows = await context.db.query.user.findMany({
+        columns: { id: true, name: true, email: true, createdAt: true },
+        orderBy: (fields, { asc: ascending }) => [ascending(fields.email)],
+    });
+
+    if (context.json) {
+        printJson({ users: rows });
+        return;
+    }
+
+    printTable(
+        ["EMAIL", "NAME", "ID", "CREATED"],
+        rows.map((row) => [row.email, text(row.name), row.id, date(row.createdAt)]),
+        "No users in this database.",
+    );
+}

--- a/scripts/cli/context.ts
+++ b/scripts/cli/context.ts
@@ -1,0 +1,155 @@
+import { and, eq, isNull } from "drizzle-orm";
+import { drizzle } from "drizzle-orm/postgres-js";
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js";
+import postgres from "postgres";
+import * as schema from "../../src/lib/server/schema";
+import { batches, urls, user } from "../../src/lib/server/schema";
+
+export type DbTarget = "local" | "preview" | "production";
+
+export type Database = PostgresJsDatabase<typeof schema>;
+
+export type User = {
+    id: string;
+    name: string;
+    email: string;
+};
+
+/** An expected failure: reported as a plain message instead of a stack trace. */
+export class CliError extends Error {
+    exitCode: number;
+
+    constructor(message: string, exitCode = 1) {
+        super(message);
+        this.name = "CliError";
+        this.exitCode = exitCode;
+    }
+}
+
+const databaseUrlEnvVar = {
+    local: "DATABASE_URL",
+    preview: "PREVIEW_DATABASE_URL",
+    production: "PRODUCTION_DATABASE_URL",
+} as const satisfies Record<DbTarget, string>;
+
+export function parseDbTarget(value: string): DbTarget {
+    if (value in databaseUrlEnvVar) return value as DbTarget;
+    throw new CliError(
+        `Unknown --db target "${value}". Expected local, preview, or production.`,
+        2,
+    );
+}
+
+export type Context = {
+    db: Database;
+    /** Where the data lives, so commands can warn about production writes. */
+    target: DbTarget;
+    json: boolean;
+    /** Resolves (and caches) the user whose batches the command operates on. */
+    requireUser: () => Promise<User>;
+    /** Refuses a mutating command against production unless --yes was passed. */
+    requireWritable: (description: string) => void;
+    close: () => Promise<void>;
+};
+
+export type ContextOptions = {
+    target: DbTarget;
+    json: boolean;
+    /** Email of the user to operate as. Falls back to REDIRECTS_USER. */
+    userEmail?: string;
+    confirmed: boolean;
+};
+
+export function createContext(options: ContextOptions): Context {
+    const envVar = databaseUrlEnvVar[options.target];
+    const databaseUrl = process.env[envVar];
+
+    if (!databaseUrl) {
+        throw new CliError(`${envVar} is not set — add it to .env to use --db ${options.target}.`);
+    }
+
+    const client = postgres(databaseUrl, { max: 4, onnotice: () => {} });
+    const db = drizzle(client, { schema });
+    let cachedUser: Promise<User> | undefined;
+
+    return {
+        db,
+        target: options.target,
+        json: options.json,
+        requireUser: () =>
+            (cachedUser ??= resolveUser(db, options.userEmail ?? process.env.REDIRECTS_USER)),
+        requireWritable: (description) => {
+            if (options.target === "production" && !options.confirmed) {
+                throw new CliError(`Refusing to ${description} in production without --yes.`, 2);
+            }
+        },
+        close: () => client.end({ timeout: 5 }),
+    };
+}
+
+async function resolveUser(db: Database, email?: string): Promise<User> {
+    const columns = { id: true, name: true, email: true } as const;
+
+    if (email) {
+        const match = await db.query.user.findFirst({
+            columns,
+            where: eq(user.email, email),
+        });
+
+        if (!match) throw new CliError(`No user with email "${email}".`);
+        return match;
+    }
+
+    // With a single account there is nothing to disambiguate, which keeps the
+    // common case flag-free.
+    const accounts = await db.query.user.findMany({ columns, limit: 2 });
+
+    if (!accounts.length) throw new CliError("No users exist in this database.");
+    if (accounts.length > 1) {
+        throw new CliError(
+            "Multiple users exist — pass --user <email> or set REDIRECTS_USER. Run `users` to list them.",
+        );
+    }
+
+    return accounts[0];
+}
+
+export type Batch = typeof batches.$inferSelect;
+export type Url = typeof urls.$inferSelect;
+
+export async function getOwnedBatch(context: Context, batchId: number): Promise<Batch> {
+    const owner = await context.requireUser();
+    const batch = await context.db.query.batches.findFirst({
+        where: and(
+            eq(batches.id, batchId),
+            eq(batches.userId, owner.id),
+            isNull(batches.deletedAt),
+        ),
+    });
+
+    if (!batch) throw new CliError(`No batch ${batchId} for ${owner.email}.`);
+    return batch;
+}
+
+export async function getOwnedUrl(
+    context: Context,
+    urlId: number,
+): Promise<{ url: Url; batch: Batch }> {
+    const owner = await context.requireUser();
+    const [row] = await context.db
+        .select({ url: urls, batch: batches })
+        .from(urls)
+        .innerJoin(batches, eq(urls.batchId, batches.id))
+        .where(
+            and(
+                eq(urls.id, urlId),
+                eq(batches.userId, owner.id),
+                isNull(urls.deletedAt),
+                isNull(batches.deletedAt),
+            ),
+        )
+        .limit(1);
+
+    if (!row) throw new CliError(`No URL ${urlId} for ${owner.email}.`);
+    return row;
+}

--- a/scripts/cli/output.ts
+++ b/scripts/cli/output.ts
@@ -1,0 +1,61 @@
+import type { Url } from "./context";
+
+const empty = "-";
+
+export function print(line = "") {
+    process.stdout.write(`${line}\n`);
+}
+
+export function printJson(value: unknown) {
+    print(JSON.stringify(value, null, 2));
+}
+
+/** Renders a left-aligned table with a two-space gutter, or a hint when empty. */
+export function printTable(headers: string[], rows: string[][], emptyHint = "No rows.") {
+    if (!rows.length) {
+        print(emptyHint);
+        return;
+    }
+
+    const widths = headers.map((header, column) =>
+        Math.max(header.length, ...rows.map((row) => (row[column] ?? "").length)),
+    );
+
+    const format = (cells: string[]) =>
+        cells
+            .map((cell, column) =>
+                column === cells.length - 1 ? cell : cell.padEnd(widths[column]),
+            )
+            .join("  ")
+            .trimEnd();
+
+    print(format(headers));
+    for (const row of rows) print(format(row));
+}
+
+export function printFields(fields: [string, string][]) {
+    const width = Math.max(...fields.map(([label]) => label.length));
+    for (const [label, value] of fields) print(`${`${label}:`.padEnd(width + 1)} ${value}`);
+}
+
+export function text(value: string | number | null | undefined) {
+    if (value === null || value === undefined || value === "") return empty;
+    return String(value);
+}
+
+export function date(value: Date | null) {
+    if (!value) return empty;
+    return value.toISOString().slice(0, 10);
+}
+
+export function statusCode(url: Pick<Url, "httpResponse">) {
+    return text(url.httpResponse?.status_code);
+}
+
+export function yesNo(value: boolean) {
+    return value ? "yes" : "no";
+}
+
+export function pluralize(count: number, singular: string, plural = `${singular}s`) {
+    return `${count} ${count === 1 ? singular : plural}`;
+}

--- a/scripts/cli/urls.ts
+++ b/scripts/cli/urls.ts
@@ -1,0 +1,283 @@
+import { and, eq, isNull, or } from "drizzle-orm";
+import {
+    checkUrl,
+    getBaseRedirectUrl,
+    getBaseUrl,
+    isValidHttpUrl,
+    normalizeUrlInput,
+    withoutTrailingSlash,
+} from "../../src/lib/server/redirects";
+import { urls } from "../../src/lib/server/schema";
+import { CliError, getOwnedBatch, getOwnedUrl } from "./context";
+import type { Batch, Context, Url } from "./context";
+import {
+    date,
+    print,
+    printFields,
+    printJson,
+    printTable,
+    pluralize,
+    statusCode,
+    text,
+    yesNo,
+} from "./output";
+
+/** The app's URL shape: the stored row plus the base-URL-relative variants. */
+export function serializeUrl(batch: Batch, url: Url) {
+    const hasBaseUrl = isValidHttpUrl(batch.baseUrl);
+    return {
+        ...url,
+        baseUrl: hasBaseUrl ? getBaseUrl(batch, url) : "",
+        baseRedirectUrl: hasBaseUrl ? getBaseRedirectUrl(batch, url) : "",
+    };
+}
+
+/** Re-requests a URL against the batch's base URL and stores the result. */
+export async function recheckUrl(context: Context, batch: Batch, url: Url): Promise<Url> {
+    if (!isValidHttpUrl(batch.baseUrl)) {
+        throw new CliError(
+            `Batch ${batch.id} has no valid base URL — set one with \`batch set-base-url ${batch.id} <url>\`.`,
+        );
+    }
+
+    const response = await checkUrl(getBaseUrl(batch, url));
+    const [updated] = await context.db
+        .update(urls)
+        .set({
+            addressed: response.status_code === 200,
+            httpResponse: response,
+            updatedAt: new Date(),
+        })
+        .where(eq(urls.id, url.id))
+        .returning();
+
+    return updated;
+}
+
+/** Runs `worker` over `items` with at most `limit` in flight, keeping order. */
+export async function mapWithConcurrency<Item, Result>(
+    items: Item[],
+    limit: number,
+    worker: (item: Item, index: number) => Promise<Result>,
+): Promise<Result[]> {
+    const results = Array.from({ length: items.length }) as Result[];
+    let next = 0;
+
+    const runners = Array.from({ length: Math.min(limit, items.length) }, async () => {
+        while (next < items.length) {
+            const index = next++;
+            results[index] = await worker(items[index], index);
+        }
+    });
+
+    await Promise.all(runners);
+    return results;
+}
+
+export async function showUrl(context: Context, urlId: number) {
+    const { url, batch } = await getOwnedUrl(context, urlId);
+    const serialized = serializeUrl(batch, url);
+
+    if (context.json) {
+        printJson({ url: serialized, batch });
+        return;
+    }
+
+    printFields([
+        ["URL", String(url.id)],
+        ["Batch", `${batch.id} (${text(batch.baseUrl)})`],
+        ["Production", url.url],
+        ["Checked as", text(serialized.baseUrl)],
+        ["Status", statusCode(url)],
+        ["Resolved", yesNo(url.addressed)],
+        ["Target", text(url.redirectTo)],
+        ["Target URL", url.redirectTo ? text(serialized.baseRedirectUrl) : text(null)],
+        ["Updated", url.updatedAt.toISOString()],
+    ]);
+
+    const chain = url.httpResponse?.redirect_chain ?? [];
+    if (chain.length) {
+        print();
+        print("Redirect chain:");
+        for (const hop of chain) {
+            const arrow = hop.redirect_to ? ` -> ${hop.redirect_to}` : "";
+            print(`  ${String(hop.status_code).padEnd(3)}  ${hop.url}${arrow}`);
+        }
+    }
+
+    if (url.httpResponse?.message) {
+        print();
+        print(`Error: ${url.httpResponse.message}`);
+    }
+}
+
+export type AddUrlsOptions = {
+    batchId: number;
+    inputs: string[];
+    check: boolean;
+    concurrency: number;
+};
+
+export async function addUrls(context: Context, options: AddUrlsOptions) {
+    context.requireWritable("add URLs");
+    const batch = await getOwnedBatch(context, options.batchId);
+
+    const lines = options.inputs.flatMap((input) => input.split("\n")).map((line) => line.trim());
+    const skipped: { url: string; reason: string }[] = [];
+    const candidates: string[] = [];
+    const seen = new Set<string>();
+
+    for (const line of lines) {
+        if (!line) continue;
+        const normalized = normalizeUrlInput(line);
+
+        if (!normalized || !isValidHttpUrl(normalized)) {
+            skipped.push({ url: line, reason: "not a valid http(s) URL" });
+            continue;
+        }
+        if (seen.has(normalized)) {
+            skipped.push({ url: normalized, reason: "duplicate in input" });
+            continue;
+        }
+
+        seen.add(normalized);
+        candidates.push(normalized);
+    }
+
+    if (!candidates.length && !skipped.length) {
+        throw new CliError("No URLs given — pass them as arguments or pipe them on stdin.");
+    }
+
+    const inserted: Url[] = [];
+    for (const candidate of candidates) {
+        const trimmed = withoutTrailingSlash(candidate);
+        const existing = await context.db.query.urls.findFirst({
+            where: and(
+                eq(urls.batchId, batch.id),
+                isNull(urls.deletedAt),
+                or(eq(urls.url, trimmed), eq(urls.url, `${trimmed}/`)),
+            ),
+        });
+
+        if (existing) {
+            skipped.push({ url: candidate, reason: `already in batch as URL ${existing.id}` });
+            continue;
+        }
+
+        const [created] = await context.db
+            .insert(urls)
+            .values({ batchId: batch.id, url: candidate })
+            .returning();
+        inserted.push(created);
+    }
+
+    const canCheck = options.check && isValidHttpUrl(batch.baseUrl);
+    const added = canCheck
+        ? await mapWithConcurrency(inserted, options.concurrency, (url) =>
+              recheckUrl(context, batch, url),
+          )
+        : inserted;
+
+    if (context.json) {
+        printJson({
+            batchId: batch.id,
+            checked: canCheck,
+            added: added.map((url) => serializeUrl(batch, url)),
+            skipped,
+        });
+        return;
+    }
+
+    printTable(
+        ["ACTION", "ID", "URL", "STATUS", "NOTE"],
+        [
+            ...added.map((url) => ["added", String(url.id), url.url, statusCode(url), ""]),
+            ...skipped.map((entry) => ["skipped", text(null), entry.url, text(null), entry.reason]),
+        ],
+        "Nothing to add.",
+    );
+    print();
+    print(
+        `${pluralize(added.length, "URL")} added, ${skipped.length} skipped.${
+            canCheck ? "" : " URLs were not checked."
+        }`,
+    );
+}
+
+export async function setUrlTarget(context: Context, urlId: number, target: string | undefined) {
+    context.requireWritable("change a redirect target");
+    const { url, batch } = await getOwnedUrl(context, urlId);
+    const redirectTo = target?.trim() || null;
+
+    if (redirectTo) {
+        const original = new URL(url.url);
+        const resolved = new URL(redirectTo, original.origin);
+        if (resolved.toString() === original.toString()) {
+            throw new CliError("Redirect target cannot be the same as the URL being redirected.");
+        }
+    }
+
+    const [updated] = await context.db
+        .update(urls)
+        .set({ redirectTo, updatedAt: new Date() })
+        .where(eq(urls.id, url.id))
+        .returning();
+
+    const serialized = serializeUrl(batch, updated);
+
+    if (context.json) {
+        printJson({ url: serialized });
+        return;
+    }
+
+    print(
+        redirectTo
+            ? `URL ${updated.id} now redirects to ${redirectTo} (${text(serialized.baseRedirectUrl)}).`
+            : `Cleared the redirect target for URL ${updated.id}.`,
+    );
+}
+
+export async function checkSingleUrl(context: Context, urlId: number) {
+    context.requireWritable("check a URL");
+    const { url, batch } = await getOwnedUrl(context, urlId);
+    const updated = await recheckUrl(context, batch, url);
+
+    if (context.json) {
+        printJson({ url: serializeUrl(batch, updated) });
+        return;
+    }
+
+    printTable(
+        ["ID", "STATUS", "RESOLVED", "URL"],
+        [[String(updated.id), statusCode(updated), yesNo(updated.addressed), updated.url]],
+    );
+}
+
+export async function deleteUrl(context: Context, urlId: number) {
+    context.requireWritable("delete a URL");
+    const { url } = await getOwnedUrl(context, urlId);
+    await context.db
+        .update(urls)
+        .set({ deletedAt: new Date(), updatedAt: new Date() })
+        .where(eq(urls.id, url.id));
+
+    if (context.json) {
+        printJson({ id: url.id, deleted: true });
+        return;
+    }
+
+    print(`Deleted URL ${url.id} (${url.url}).`);
+}
+
+export function urlRow(url: Url) {
+    return [
+        String(url.id),
+        statusCode(url),
+        yesNo(url.addressed),
+        url.url,
+        text(url.redirectTo),
+        date(url.updatedAt),
+    ];
+}
+
+export const urlColumns = ["ID", "STATUS", "RESOLVED", "URL", "TARGET", "UPDATED"];

--- a/scripts/cli/urls.ts
+++ b/scripts/cli/urls.ts
@@ -135,12 +135,13 @@ export async function addUrls(context: Context, options: AddUrlsOptions) {
             skipped.push({ url: line, reason: "not a valid http(s) URL" });
             continue;
         }
-        if (seen.has(normalized)) {
+        const dedupeKey = withoutTrailingSlash(normalized);
+        if (seen.has(dedupeKey)) {
             skipped.push({ url: normalized, reason: "duplicate in input" });
             continue;
         }
 
-        seen.add(normalized);
+        seen.add(dedupeKey);
         candidates.push(normalized);
     }
 

--- a/scripts/redirects.ts
+++ b/scripts/redirects.ts
@@ -70,6 +70,30 @@ const valueFlags = new Set(["user", "db", "filter", "limit", "format", "concurre
 
 type Flags = Record<string, string | boolean | undefined>;
 
+const commonFlags = ["json", "user", "db"] as const;
+
+type CommandUsage = {
+    minArgs: number;
+    maxArgs?: number;
+    flags?: readonly string[];
+};
+
+const commandUsage = {
+    batches: { minArgs: 0, maxArgs: 0 },
+    users: { minArgs: 0, maxArgs: 0 },
+    "batch show": { minArgs: 1, maxArgs: 1, flags: ["filter", "limit"] },
+    "batch create": { minArgs: 1, maxArgs: 1, flags: ["yes"] },
+    "batch set-base-url": { minArgs: 2, maxArgs: 2, flags: ["yes"] },
+    "batch check": { minArgs: 1, maxArgs: 1, flags: ["yes", "filter", "concurrency"] },
+    "batch redirects": { minArgs: 1, maxArgs: 1, flags: ["format"] },
+    "batch archive": { minArgs: 1, maxArgs: 1, flags: ["yes"] },
+    "urls add": { minArgs: 1, flags: ["yes", "no-check", "concurrency"] },
+    "url show": { minArgs: 1, maxArgs: 1 },
+    "url set-target": { minArgs: 1, maxArgs: 2, flags: ["yes"] },
+    "url check": { minArgs: 1, maxArgs: 1, flags: ["yes"] },
+    "url delete": { minArgs: 1, maxArgs: 1, flags: ["yes"] },
+} as const satisfies Record<string, CommandUsage>;
+
 function parseArgv(argv: string[]) {
     const positional: string[] = [];
     const flags: Flags = {};
@@ -109,6 +133,44 @@ function parseArgv(argv: string[]) {
     }
 
     return { positional, flags };
+}
+
+function invocation(positional: string[]) {
+    const [command, first, ...remaining] = positional;
+
+    if (command === "batch") {
+        return Number.isInteger(Number(first))
+            ? { name: "batch show", args: positional.slice(1) }
+            : { name: `batch ${first ?? ""}`, args: remaining };
+    }
+
+    if (command === "url") {
+        return Number.isInteger(Number(first))
+            ? { name: "url show", args: positional.slice(1) }
+            : { name: `url ${first ?? ""}`, args: remaining };
+    }
+
+    if (command === "urls") return { name: `urls ${first ?? ""}`, args: remaining };
+    return { name: command ?? "", args: positional.slice(1) };
+}
+
+function validateInvocation(positional: string[], flags: Flags) {
+    const { name, args } = invocation(positional);
+    const rules = commandUsage[name as keyof typeof commandUsage];
+    if (!rules) return;
+
+    const allowedFlags = new Set<string>([...commonFlags, ...(rules.flags ?? [])]);
+    const unsupported = Object.keys(flags).find((flag) => !allowedFlags.has(flag));
+    if (unsupported) {
+        throw new CliError(`--${unsupported} does not apply to \`${name}\`.`, 2);
+    }
+
+    if (
+        args.length < rules.minArgs ||
+        (rules.maxArgs !== undefined && args.length > rules.maxArgs)
+    ) {
+        throw new CliError(`Wrong number of arguments for \`${name}\`. Run \`help\` for usage.`, 2);
+    }
 }
 
 function flagString(flags: Flags, name: string) {
@@ -151,103 +213,61 @@ async function readStdin() {
 }
 
 async function run(context: Context, positional: string[], flags: Flags) {
-    const [command, ...rest] = positional;
-    const filter = parseUrlFilter(flagString(flags, "filter") ?? "all");
-    const concurrency = flagNumber(flags, "concurrency", 6);
+    const { name, args } = invocation(positional);
 
-    switch (command) {
+    switch (name) {
         case "batches":
             return listBatches(context);
 
         case "users":
             return listUsers(context);
 
-        case "batch": {
-            // `batch 12` is shorthand for `batch show 12`.
-            const [subcommand, ...args] = Number.isInteger(Number(rest[0]))
-                ? ["show", ...rest]
-                : rest;
-
-            switch (subcommand) {
-                case "show":
-                    return showBatch(context, {
-                        batchId: requireId(args[0], "batch"),
-                        filter,
-                        limit: flagString(flags, "limit")
-                            ? flagNumber(flags, "limit", 0)
-                            : undefined,
-                    });
-                case "create":
-                    return createBatch(context, requireArgument(args[0], "base URL"));
-                case "set-base-url":
-                    return setBaseUrl(
-                        context,
-                        requireId(args[0], "batch"),
-                        requireArgument(args[1], "base URL"),
-                    );
-                case "check":
-                    return checkBatch(context, {
-                        batchId: requireId(args[0], "batch"),
-                        filter,
-                        concurrency,
-                    });
-                case "redirects":
-                    return batchRedirects(context, {
-                        batchId: requireId(args[0], "batch"),
-                        format: flagString(flags, "format") ?? "apache",
-                    });
-                case "archive":
-                    return archiveBatch(context, requireId(args[0], "batch"));
-                default:
-                    throw new CliError(
-                        `Unknown batch subcommand "${subcommand ?? ""}". Run \`help\` for usage.`,
-                        2,
-                    );
-            }
-        }
-
-        case "urls": {
-            const [subcommand, ...args] = rest;
-            if (subcommand !== "add") {
-                throw new CliError(
-                    `Unknown urls subcommand "${subcommand ?? ""}". Did you mean \`urls add\`?`,
-                    2,
-                );
-            }
-
+        case "batch show":
+            return showBatch(context, {
+                batchId: requireId(args[0], "batch"),
+                filter: parseUrlFilter(flagString(flags, "filter") ?? "all"),
+                limit: flagString(flags, "limit") ? flagNumber(flags, "limit", 0) : undefined,
+            });
+        case "batch create":
+            return createBatch(context, requireArgument(args[0], "base URL"));
+        case "batch set-base-url":
+            return setBaseUrl(
+                context,
+                requireId(args[0], "batch"),
+                requireArgument(args[1], "base URL"),
+            );
+        case "batch check":
+            return checkBatch(context, {
+                batchId: requireId(args[0], "batch"),
+                filter: parseUrlFilter(flagString(flags, "filter") ?? "all"),
+                concurrency: flagNumber(flags, "concurrency", 6),
+            });
+        case "batch redirects":
+            return batchRedirects(context, {
+                batchId: requireId(args[0], "batch"),
+                format: flagString(flags, "format") ?? "apache",
+            });
+        case "batch archive":
+            return archiveBatch(context, requireId(args[0], "batch"));
+        case "urls add": {
             const inputs = args.slice(1);
             return addUrls(context, {
                 batchId: requireId(args[0], "batch"),
                 inputs: inputs.length ? inputs : await readStdin(),
                 check: flags["no-check"] !== true,
-                concurrency,
+                concurrency: flagNumber(flags, "concurrency", 6),
             });
         }
-
-        case "url": {
-            const [subcommand, ...args] = Number.isInteger(Number(rest[0]))
-                ? ["show", ...rest]
-                : rest;
-
-            switch (subcommand) {
-                case "show":
-                    return showUrl(context, requireId(args[0], "URL"));
-                case "set-target":
-                    return setUrlTarget(context, requireId(args[0], "URL"), args[1]);
-                case "check":
-                    return checkSingleUrl(context, requireId(args[0], "URL"));
-                case "delete":
-                    return deleteUrl(context, requireId(args[0], "URL"));
-                default:
-                    throw new CliError(
-                        `Unknown url subcommand "${subcommand ?? ""}". Run \`help\` for usage.`,
-                        2,
-                    );
-            }
-        }
-
+        case "url show":
+            return showUrl(context, requireId(args[0], "URL"));
+        case "url set-target":
+            return setUrlTarget(context, requireId(args[0], "URL"), args[1]);
+        case "url check":
+            return checkSingleUrl(context, requireId(args[0], "URL"));
+        case "url delete":
+            return deleteUrl(context, requireId(args[0], "URL"));
         default:
-            throw new CliError(`Unknown command "${command}". Run \`help\` for usage.`, 2);
+            throw new CliError(`Unknown command "${name}". Run \`help\` for usage.`, 2);
     }
 }
 
@@ -258,6 +278,8 @@ async function main() {
         print(usage);
         return;
     }
+
+    validateInvocation(positional, flags);
 
     const context = createContext({
         target: parseDbTarget(flagString(flags, "db") ?? "local"),

--- a/scripts/redirects.ts
+++ b/scripts/redirects.ts
@@ -1,0 +1,285 @@
+#!/usr/bin/env bun
+import {
+    archiveBatch,
+    batchRedirects,
+    checkBatch,
+    createBatch,
+    listBatches,
+    listUsers,
+    parseUrlFilter,
+    setBaseUrl,
+    showBatch,
+} from "./cli/batches";
+import { CliError, createContext, parseDbTarget } from "./cli/context";
+import type { Context } from "./cli/context";
+import { print } from "./cli/output";
+import { addUrls, checkSingleUrl, deleteUrl, setUrlTarget, showUrl } from "./cli/urls";
+
+const usage = `redirects — inspect and edit Redirects Wizard data from the command line.
+
+Usage
+  ./scripts/redirects.ts <command> [arguments] [flags]
+
+Batches
+  batches                          List batches with URL and unresolved counts
+  batch <id>                       Show a batch and its URLs
+  batch create <base-url>          Create a batch for a base URL
+  batch set-base-url <id> <url>    Point a batch at a different base URL
+  batch check <id>                 Re-request the batch's URLs and store statuses
+  batch redirects <id>             Print generated redirect rules
+  batch archive <id>               Archive (soft-delete) a batch
+
+URLs
+  urls add <batch-id> [url...]     Add production URLs; reads stdin when none are given
+  url <id>                         Show one URL with its redirect chain
+  url set-target <id> [target]     Set the redirect target; omit it to clear
+  url check <id>                   Re-request one URL and store the status
+  url delete <id>                  Delete (soft-delete) a URL
+
+Other
+  users                            List accounts, for use with --user
+  help                             Show this message
+
+Flags
+  --json                 Emit JSON instead of tables
+  --user <email>         Account to act as (default: REDIRECTS_USER, or the only account)
+  --db <target>          local (default), preview, or production
+  --yes                  Allow a mutating command to run against --db production
+  --filter <name>        all (default), unresolved, resolved, or untargeted
+                         Applies to \`batch <id>\` and \`batch check\`
+  --limit <n>            Cap the URLs listed by \`batch <id>\`
+  --format <id>          apache (default), nginx, caddy, netlify, next-js, astro, or all
+  --no-check             Skip the HTTP check when adding URLs
+  --concurrency <n>      Parallel HTTP checks (default 6)
+
+Notes
+  Connection strings come from .env (DATABASE_URL, PREVIEW_DATABASE_URL,
+  PRODUCTION_DATABASE_URL). Unlike the web app, \`batch create\` does not
+  capture a screenshot.
+
+Examples
+  ./scripts/redirects.ts batches
+  ./scripts/redirects.ts batch 12 --filter untargeted
+  pbpaste | ./scripts/redirects.ts urls add 12
+  ./scripts/redirects.ts url set-target 480 /new-page
+  ./scripts/redirects.ts batch check 12 --filter unresolved
+  ./scripts/redirects.ts batch redirects 12 --format nginx`;
+
+const booleanFlags = new Set(["json", "yes", "no-check", "help"]);
+const valueFlags = new Set(["user", "db", "filter", "limit", "format", "concurrency"]);
+
+type Flags = Record<string, string | boolean | undefined>;
+
+function parseArgv(argv: string[]) {
+    const positional: string[] = [];
+    const flags: Flags = {};
+
+    for (let index = 0; index < argv.length; index++) {
+        const arg = argv[index];
+
+        if (arg === "--") {
+            positional.push(...argv.slice(index + 1));
+            break;
+        }
+
+        if (!arg.startsWith("--")) {
+            positional.push(arg);
+            continue;
+        }
+
+        const separator = arg.indexOf("=");
+        const name = separator === -1 ? arg.slice(2) : arg.slice(2, separator);
+        const inlineValue = separator === -1 ? undefined : arg.slice(separator + 1);
+
+        if (booleanFlags.has(name)) {
+            if (inlineValue !== undefined) {
+                throw new CliError(`--${name} does not take a value.`, 2);
+            }
+            flags[name] = true;
+            continue;
+        }
+
+        if (!valueFlags.has(name)) {
+            throw new CliError(`Unknown flag --${name}. Run \`help\` for the flag list.`, 2);
+        }
+
+        const value = inlineValue ?? argv[++index];
+        if (value === undefined) throw new CliError(`--${name} needs a value.`, 2);
+        flags[name] = value;
+    }
+
+    return { positional, flags };
+}
+
+function flagString(flags: Flags, name: string) {
+    const value = flags[name];
+    return typeof value === "string" ? value : undefined;
+}
+
+function flagNumber(flags: Flags, name: string, fallback: number) {
+    const value = flagString(flags, name);
+    if (value === undefined) return fallback;
+
+    const parsed = Number(value);
+    if (!Number.isInteger(parsed) || parsed < 1) {
+        throw new CliError(`--${name} must be a positive integer.`, 2);
+    }
+
+    return parsed;
+}
+
+function requireId(value: string | undefined, label: string) {
+    const parsed = Number(value);
+    if (!value || !Number.isInteger(parsed) || parsed < 1) {
+        throw new CliError(`Expected a numeric ${label} id, got "${value ?? ""}".`, 2);
+    }
+
+    return parsed;
+}
+
+function requireArgument(value: string | undefined, label: string) {
+    if (!value) throw new CliError(`Missing ${label}. Run \`help\` for usage.`, 2);
+    return value;
+}
+
+async function readStdin() {
+    if (process.stdin.isTTY) return [];
+
+    const chunks: Buffer[] = [];
+    for await (const chunk of process.stdin) chunks.push(Buffer.from(chunk));
+    return [Buffer.concat(chunks).toString("utf8")];
+}
+
+async function run(context: Context, positional: string[], flags: Flags) {
+    const [command, ...rest] = positional;
+    const filter = parseUrlFilter(flagString(flags, "filter") ?? "all");
+    const concurrency = flagNumber(flags, "concurrency", 6);
+
+    switch (command) {
+        case "batches":
+            return listBatches(context);
+
+        case "users":
+            return listUsers(context);
+
+        case "batch": {
+            // `batch 12` is shorthand for `batch show 12`.
+            const [subcommand, ...args] = Number.isInteger(Number(rest[0]))
+                ? ["show", ...rest]
+                : rest;
+
+            switch (subcommand) {
+                case "show":
+                    return showBatch(context, {
+                        batchId: requireId(args[0], "batch"),
+                        filter,
+                        limit: flagString(flags, "limit")
+                            ? flagNumber(flags, "limit", 0)
+                            : undefined,
+                    });
+                case "create":
+                    return createBatch(context, requireArgument(args[0], "base URL"));
+                case "set-base-url":
+                    return setBaseUrl(
+                        context,
+                        requireId(args[0], "batch"),
+                        requireArgument(args[1], "base URL"),
+                    );
+                case "check":
+                    return checkBatch(context, {
+                        batchId: requireId(args[0], "batch"),
+                        filter,
+                        concurrency,
+                    });
+                case "redirects":
+                    return batchRedirects(context, {
+                        batchId: requireId(args[0], "batch"),
+                        format: flagString(flags, "format") ?? "apache",
+                    });
+                case "archive":
+                    return archiveBatch(context, requireId(args[0], "batch"));
+                default:
+                    throw new CliError(
+                        `Unknown batch subcommand "${subcommand ?? ""}". Run \`help\` for usage.`,
+                        2,
+                    );
+            }
+        }
+
+        case "urls": {
+            const [subcommand, ...args] = rest;
+            if (subcommand !== "add") {
+                throw new CliError(
+                    `Unknown urls subcommand "${subcommand ?? ""}". Did you mean \`urls add\`?`,
+                    2,
+                );
+            }
+
+            const inputs = args.slice(1);
+            return addUrls(context, {
+                batchId: requireId(args[0], "batch"),
+                inputs: inputs.length ? inputs : await readStdin(),
+                check: flags["no-check"] !== true,
+                concurrency,
+            });
+        }
+
+        case "url": {
+            const [subcommand, ...args] = Number.isInteger(Number(rest[0]))
+                ? ["show", ...rest]
+                : rest;
+
+            switch (subcommand) {
+                case "show":
+                    return showUrl(context, requireId(args[0], "URL"));
+                case "set-target":
+                    return setUrlTarget(context, requireId(args[0], "URL"), args[1]);
+                case "check":
+                    return checkSingleUrl(context, requireId(args[0], "URL"));
+                case "delete":
+                    return deleteUrl(context, requireId(args[0], "URL"));
+                default:
+                    throw new CliError(
+                        `Unknown url subcommand "${subcommand ?? ""}". Run \`help\` for usage.`,
+                        2,
+                    );
+            }
+        }
+
+        default:
+            throw new CliError(`Unknown command "${command}". Run \`help\` for usage.`, 2);
+    }
+}
+
+async function main() {
+    const { positional, flags } = parseArgv(process.argv.slice(2));
+
+    if (!positional.length || positional[0] === "help" || flags.help === true) {
+        print(usage);
+        return;
+    }
+
+    const context = createContext({
+        target: parseDbTarget(flagString(flags, "db") ?? "local"),
+        json: flags.json === true,
+        userEmail: flagString(flags, "user"),
+        confirmed: flags.yes === true,
+    });
+
+    try {
+        await run(context, positional, flags);
+    } finally {
+        await context.close();
+    }
+}
+
+try {
+    await main();
+} catch (error) {
+    if (error instanceof CliError) {
+        process.stderr.write(`${error.message}\n`);
+        process.exit(error.exitCode);
+    }
+
+    throw error;
+}


### PR DESCRIPTION
## What

Adds `scripts/redirects.ts`, a CLI over the same batch and URL data the app manages, so redirect work can be scripted or driven by an AI agent.

```
scripts/redirects.ts     entry: arg parsing, dispatch, help
scripts/cli/context.ts   db connection, user scoping, production write guard
scripts/cli/batches.ts   batch commands + users
scripts/cli/urls.ts      url commands + shared check/serialize helpers
scripts/cli/output.ts    table/JSON/field rendering
```

| Command | Description |
| --- | --- |
| `batches` | List batches with URL, unresolved, and untargeted counts |
| `batch <id>` | Show a batch and its URLs |
| `batch create <base-url>` | Create a batch for a base URL |
| `batch set-base-url <id> <url>` | Point a batch at a different base URL |
| `batch check <id>` | Re-request the batch's URLs and store their statuses |
| `batch redirects <id>` | Print generated redirect rules |
| `batch archive <id>` | Archive (soft-delete) a batch |
| `urls add <batch-id> [url...]` | Add production URLs; reads stdin when none are given |
| `url <id>` | Show one URL with its redirect chain |
| `url set-target <id> [target]` | Set the redirect target; omit it to clear |
| `url check <id>` | Re-request one URL and store the status |
| `url delete <id>` | Delete (soft-delete) a URL |
| `users` | List accounts, for use with `--user` |

## Why direct database access instead of the HTTP API

The `/api/*` routes require a better-auth session cookie and support no token auth, so they cannot be called from a shell. The CLI connects to Postgres with Drizzle using the connection strings already in `.env`, and imports `src/lib/server/redirects.ts` directly — rule generation, URL normalization, and the HTTP-check logic are the same code paths as the app, not a reimplementation.

## Notes

- Every command accepts `--json`.
- `urls add` reads URLs from stdin when none are passed, and reports each input as added or skipped with a reason (invalid, duplicate in input, already in batch).
- `--filter unresolved|resolved|untargeted` applies to `batch <id>` and `batch check`; `untargeted` is the actual worklist.
- `batch redirects <id> --format nginx` prints raw rules; `--format all` prints every format. The rule set mirrors `/api/batches/[id]/redirects` (unresolved URLs with a target set).
- Ownership scoping matches the app. With a single account no flag is needed; otherwise `--user <email>` or `REDIRECTS_USER`.
- `--db local|preview|production` selects `DATABASE_URL`, `PREVIEW_DATABASE_URL`, or `PRODUCTION_DATABASE_URL`. Reads work against any target; writes to production also require `--yes`, and the guard trips before a connection is opened.
- Exit codes: 1 for operational failures, 2 for usage errors.
- `batch create` does not capture a screenshot: `src/lib/server/screenshots.ts` imports `$env/dynamic/private` and cannot load outside SvelteKit. Noted in `--help` and the README.

## Testing

Verified end to end against a local Postgres: created a batch, added URLs with live HTTP checks (input dedupe and trailing-slash matching both fired), set and cleared redirect targets, ran `batch check` at concurrency 2 and 3, generated all six formats, deleted a URL, archived a batch, and listed batches from the preview database. Also exercised the production write guard, cross-account 404s, and each usage-error path. `tsc --strict` is clean over the CLI; `bun run lint` reports only the pre-existing `scripts/dokploy-preview.mjs` warning.

https://claude.ai/code/session_016mG8MZHjLdU5tLBXYoEvgb

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a command-line interface for managing redirect batches and URLs.
  * Create, update, inspect, check, archive, and delete redirect data.
  * Generate redirects in supported formats and import URLs from files or standard input.
  * View results as human-readable tables or JSON, with filtering, limits, and concurrency controls.
  * Select database targets with safeguards for production changes.

* **Documentation**
  * Added CLI usage guidance, supported commands and flags, safety information, and migration workflow examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->