### PR TITLE
Show a placeholder when a batch screenshot file is missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,13 @@ at that path in Dokploy (e.g. `/data/screenshots`) so screenshots survive
 redeploys. Screenshots are (re)captured when a batch's base URL is set and via
 the refresh button on each batch card.
 
+Only the timestamp lives in Postgres — the image itself is a file on disk, so the
+two can drift. Copying the production database (`bun db:copy-production-to-local`)
+brings timestamps for batches whose images stay on the production volume, and a
+redeploy without the volume mounted loses images the database still points at.
+Drifted batches show the "No screenshot yet" placeholder; the refresh button
+re-captures them.
+
 For local development, install the browser once:
 
 ```sh

--- a/bun.lock
+++ b/bun.lock
@@ -19,20 +19,20 @@
       "devDependencies": {
         "@fontsource-variable/inter": "^5.3.0",
         "@internationalized/date": "^3.12.3",
-        "@lucide/svelte": "^1.28.0",
+        "@lucide/svelte": "^1.30.0",
         "@sveltejs/kit": "^2.70.2",
-        "@sveltejs/vite-plugin-svelte": "^7.2.0",
-        "@types/node": "^26.1.2",
+        "@sveltejs/vite-plugin-svelte": "^7.3.0",
+        "@types/node": "^26.2.0",
         "bits-ui": "^2.18.1",
         "drizzle-kit": "^0.31.10",
         "lefthook": "^2.1.10",
         "shadcn-svelte": "^1.5.0",
         "svelte-adapter-bun": "^1.0.1",
-        "svelte-check": "^4.7.4",
+        "svelte-check": "^4.7.5",
         "tailwind-variants": "^3.3.1",
         "tw-animate-css": "^1.4.0",
         "typescript": "^6.0.3",
-        "vite": "^8.2.0",
+        "vite": "^8.2.1",
       },
     },
   },
@@ -139,7 +139,7 @@
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
 
-    "@lucide/svelte": ["@lucide/svelte@1.28.0", "", { "peerDependencies": { "svelte": "^5" } }, "sha512-C1Ge84KW2z4q44/WDIEo/2KC2jby5u6mSlta7q+p6g7u0ld8sC/w1fMBiSswF+4bxAl9jlzzaVTpp79qqkiy5g=="],
+    "@lucide/svelte": ["@lucide/svelte@1.30.0", "", { "peerDependencies": { "svelte": "^5" } }, "sha512-KtVrqWT3BD41kf1CPaP4QTAyofw0xm5hw/JGwd76+wMk1l0ZcXskA2Wi9ANVWCsk7mGrpFo2SqL3Hl29xTkV3w=="],
 
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.4", "", { "dependencies": { "@tybys/wasm-util": "^0.10.1" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow=="],
 
@@ -191,9 +191,9 @@
 
     "@sveltejs/kit": ["@sveltejs/kit@2.70.2", "", { "dependencies": { "@standard-schema/spec": "^1.0.0", "@sveltejs/acorn-typescript": "^1.0.9", "@types/cookie": "^0.6.0", "acorn": "^8.16.0", "cookie": "^0.6.0", "devalue": "^5.8.1", "esm-env": "^1.2.2", "kleur": "^4.1.5", "magic-string": "^0.30.5", "mrmime": "^2.0.0", "set-cookie-parser": "^3.0.0", "sirv": "^3.0.0" }, "peerDependencies": { "@opentelemetry/api": "^1.0.0", "@sveltejs/vite-plugin-svelte": "^3.0.0 || ^4.0.0-next.1 || ^5.0.0 || ^6.0.0-next.0 || ^7.0.0", "svelte": "^4.0.0 || ^5.0.0-next.0", "typescript": "^5.3.3 || ^6.0.0", "vite": "^5.0.3 || ^6.0.0 || ^7.0.0-beta.0 || ^8.0.0" }, "optionalPeers": ["@opentelemetry/api", "typescript"], "bin": { "svelte-kit": "svelte-kit.js" } }, "sha512-RzRoRpuR2KXqc5yMO0akQHDZeT4AslOlznGITURsqHaVbtyYP4Wn3eE3gxj9JcDyNYO0crkxhdwFHc+2vkVm6w=="],
 
-    "@sveltejs/load-config": ["@sveltejs/load-config@0.2.1", "", {}, "sha512-5m3B2cbqQ4TbwW6Xkh66Ntw6dD7gNc77cCxABTTesWcq9jxIzMgTk97pZx5vEtvQx8iokgi7GIphqZe+PGwcZA=="],
+    "@sveltejs/load-config": ["@sveltejs/load-config@0.2.2", "", {}, "sha512-K7dsJDQxBOF+f+epuhMactcjK2VP4MRkLKtwSykNtEI+cKVEyzrmmhQ1pmoxI800m4JKcyJ05L2M4yPwAGiBNw=="],
 
-    "@sveltejs/vite-plugin-svelte": ["@sveltejs/vite-plugin-svelte@7.2.0", "", { "dependencies": { "deepmerge": "^4.3.1", "magic-string": "^0.30.21", "obug": "^2.1.0", "vitefu": "^1.1.2" }, "peerDependencies": { "svelte": "^5.46.4", "vite": "^8.0.0-beta.7 || ^8.0.0" } }, "sha512-1SpkuMSRLfugrVX+IrKfE1RUegzo8AQzKQ6qQPfVzbcWi5IhuTPaKb5ZrLpucleFznkc4/RTeSPoRnGWFxX+EQ=="],
+    "@sveltejs/vite-plugin-svelte": ["@sveltejs/vite-plugin-svelte@7.3.0", "", { "dependencies": { "deepmerge": "^4.3.1", "magic-string": "^1.0.0", "obug": "^2.1.0", "vitefu": "^1.1.2" }, "peerDependencies": { "svelte": "^5.46.4", "vite": "^8.0.0-beta.7 || ^8.0.0" } }, "sha512-QbRoJyD92e9R0ufeQIWRHrCC0ObcqSv/aBDdrQMoU+sypav3cDx5wytdQ6GLdXjEMO6xjrXGzfkUygng8JMv0A=="],
 
     "@swc/helpers": ["@swc/helpers@0.5.23", "", { "dependencies": { "tslib": "^2.8.0" } }, "sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw=="],
 
@@ -233,7 +233,7 @@
 
     "@types/estree": ["@types/estree@1.0.9", "", {}, "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg=="],
 
-    "@types/node": ["@types/node@26.1.2", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-Vu4a5UFA9rIIFJ7rB/Vaafh9lrCQszopTCx6KjFboXTGQbPNasehVR5TEiithSDGyd1DEiUByggTZsg8jukeIg=="],
+    "@types/node": ["@types/node@26.2.0", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-5IviulTZeRNp2vAJ514cc/HUlY5nZ9fCbq9DMyC52BrhFZACo3nI0R7qBxhQmo/d27NFe96ur/b7Wwxklda+kg=="],
 
     "@types/trusted-types": ["@types/trusted-types@2.0.7", "", {}, "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw=="],
 
@@ -411,7 +411,7 @@
 
     "svelte-adapter-bun": ["svelte-adapter-bun@1.0.1", "", { "dependencies": { "rolldown": "^1.0.0-beta.38" }, "peerDependencies": { "@sveltejs/kit": "^2.4.0", "typescript": "^5" } }, "sha512-tNOvfm8BGgG+rmEA7hkmqtq07v7zoo4skLQc+hIoQ79J+1fkEMpJEA2RzCIe3aPc8JdrsMJkv3mpiZPMsgahjA=="],
 
-    "svelte-check": ["svelte-check@4.7.4", "", { "dependencies": { "@jridgewell/trace-mapping": "^0.3.25", "@sveltejs/load-config": "^0.2.1", "chokidar": "^4.0.1", "fdir": "^6.2.0", "picocolors": "^1.0.0", "sade": "^1.7.4" }, "peerDependencies": { "svelte": "^4.0.0 || ^5.0.0-next.0", "typescript": "^5.0.0 || ^6.0.0" }, "bin": { "svelte-check": "bin/svelte-check" } }, "sha512-IW9ot9YqAoyv8FvyN+eb4ZTe8zgcKZrJLNYU6dzSKkGwEBsSPc4K7lmQ8bKn8W2YMXM6WDfZSSVOaGtekyUfOQ=="],
+    "svelte-check": ["svelte-check@4.7.5", "", { "dependencies": { "@jridgewell/trace-mapping": "^0.3.25", "@sveltejs/load-config": "^0.2.2", "chokidar": "^4.0.1", "fdir": "^6.2.0", "picocolors": "^1.0.0", "sade": "^1.7.4" }, "peerDependencies": { "svelte": "^4.0.0 || ^5.0.0-next.0", "typescript": "^5.0.0 || ^6.0.0" }, "bin": { "svelte-check": "bin/svelte-check" } }, "sha512-NnkHGCTPH6k4ka1E9IpTuNv40uLArHnX52kLEuaHSGqRlPYTnkbFs529jSWG+y+wDy+v+jA2PQ0soN1umVK+OA=="],
 
     "svelte-toolbelt": ["svelte-toolbelt@0.10.6", "", { "dependencies": { "clsx": "^2.1.1", "runed": "^0.35.1", "style-to-object": "^1.0.8" }, "peerDependencies": { "svelte": "^5.30.2" } }, "sha512-YWuX+RE+CnWYx09yseAe4ZVMM7e7GRFZM6OYWpBKOb++s+SQ8RBIMMe+Bs/CznBMc0QPLjr+vDBxTAkozXsFXQ=="],
 
@@ -439,7 +439,7 @@
 
     "undici-types": ["undici-types@8.3.0", "", {}, "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ=="],
 
-    "vite": ["vite@8.2.0", "", { "dependencies": { "lightningcss": "^1.33.0", "picomatch": "^4.0.5", "postcss": "^8.5.23", "rolldown": "~1.2.0", "tinyglobby": "^0.2.17" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.4.0", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-pn+CFpM0lwDeKwmOq1ZaBK/9sjorZcgqxki6MbY/jPEVd9vichIlmlD4HmQ5wdP5EgqQCFRaACBxMC7uEGc6lQ=="],
+    "vite": ["vite@8.2.1", "", { "dependencies": { "lightningcss": "^1.33.0", "picomatch": "^4.0.5", "postcss": "^8.5.25", "rolldown": "~1.2.1", "tinyglobby": "^0.2.17" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.4.0", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-EU/eS7BH3XROHh2YnBefjM6DBKA6ZeMZEYQbj7NLWg5wHYlhB8B/Mayd5XsgWq+NFYccDOTemRpdETWR6Ka/lw=="],
 
     "vitefu": ["vitefu@1.1.3", "", { "peerDependencies": { "vite": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0" }, "optionalPeers": ["vite"] }, "sha512-ub4okH7Z5KLjb6hDyjqrGXqWtWvoYdU3IGm/NorpgHncKoLTCfRIbvlhBm7r0YstIaQRYlp4yEbFqDcKSzXSSg=="],
 
@@ -448,6 +448,8 @@
     "zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
 
     "@esbuild-kit/core-utils/esbuild": ["esbuild@0.18.20", "", { "optionalDependencies": { "@esbuild/android-arm": "0.18.20", "@esbuild/android-arm64": "0.18.20", "@esbuild/android-x64": "0.18.20", "@esbuild/darwin-arm64": "0.18.20", "@esbuild/darwin-x64": "0.18.20", "@esbuild/freebsd-arm64": "0.18.20", "@esbuild/freebsd-x64": "0.18.20", "@esbuild/linux-arm": "0.18.20", "@esbuild/linux-arm64": "0.18.20", "@esbuild/linux-ia32": "0.18.20", "@esbuild/linux-loong64": "0.18.20", "@esbuild/linux-mips64el": "0.18.20", "@esbuild/linux-ppc64": "0.18.20", "@esbuild/linux-riscv64": "0.18.20", "@esbuild/linux-s390x": "0.18.20", "@esbuild/linux-x64": "0.18.20", "@esbuild/netbsd-x64": "0.18.20", "@esbuild/openbsd-x64": "0.18.20", "@esbuild/sunos-x64": "0.18.20", "@esbuild/win32-arm64": "0.18.20", "@esbuild/win32-ia32": "0.18.20", "@esbuild/win32-x64": "0.18.20" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA=="],
+
+    "@sveltejs/vite-plugin-svelte/magic-string": ["magic-string@1.1.0", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-kS3VHe0nEPST2saQV4Rbkchcd3UBRkVTQHo1D3h/ZTwFDhai/mfKkmtPAtD129EOI7K3HlHIsFOt0WrI2/oU9g=="],
 
     "@tailwindcss/node/lightningcss": ["lightningcss@1.32.0", "", { "dependencies": { "detect-libc": "^2.0.3" }, "optionalDependencies": { "lightningcss-android-arm64": "1.32.0", "lightningcss-darwin-arm64": "1.32.0", "lightningcss-darwin-x64": "1.32.0", "lightningcss-freebsd-x64": "1.32.0", "lightningcss-linux-arm-gnueabihf": "1.32.0", "lightningcss-linux-arm64-gnu": "1.32.0", "lightningcss-linux-arm64-musl": "1.32.0", "lightningcss-linux-x64-gnu": "1.32.0", "lightningcss-linux-x64-musl": "1.32.0", "lightningcss-win32-arm64-msvc": "1.32.0", "lightningcss-win32-x64-msvc": "1.32.0" } }, "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ=="],
 

--- a/package.json
+++ b/package.json
@@ -32,19 +32,19 @@
     "devDependencies": {
         "@fontsource-variable/inter": "^5.3.0",
         "@internationalized/date": "^3.12.3",
-        "@lucide/svelte": "^1.28.0",
+        "@lucide/svelte": "^1.30.0",
         "@sveltejs/kit": "^2.70.2",
-        "@sveltejs/vite-plugin-svelte": "^7.2.0",
-        "@types/node": "^26.1.2",
+        "@sveltejs/vite-plugin-svelte": "^7.3.0",
+        "@types/node": "^26.2.0",
         "bits-ui": "^2.18.1",
         "drizzle-kit": "^0.31.10",
         "lefthook": "^2.1.10",
         "shadcn-svelte": "^1.5.0",
         "svelte-adapter-bun": "^1.0.1",
-        "svelte-check": "^4.7.4",
+        "svelte-check": "^4.7.5",
         "tailwind-variants": "^3.3.1",
         "tw-animate-css": "^1.4.0",
         "typescript": "^6.0.3",
-        "vite": "^8.2.0"
+        "vite": "^8.2.1"
     }
 }

--- a/src/lib/server/screenshots.ts
+++ b/src/lib/server/screenshots.ts
@@ -1,4 +1,4 @@
-import { mkdir, writeFile } from "node:fs/promises";
+import { mkdir, stat, writeFile } from "node:fs/promises";
 import { join, resolve } from "node:path";
 import { env } from "$env/dynamic/private";
 import type { Browser, Page } from "playwright";
@@ -92,6 +92,20 @@ async function resetBrowser(): Promise<void> {
 
 export function screenshotFilePath(batchId: number): string {
     return join(STORAGE_DIR, `${batchId}.jpg`);
+}
+
+// batches.screenshotUpdatedAt lives in Postgres while the JPEG lives on disk, so
+// the two can drift: a database copied between environments, a redeploy without
+// the persistent volume mounted, or a wiped local .screenshots folder all leave
+// rows claiming a screenshot that no longer exists. Callers check here so the UI
+// can fall back to its placeholder instead of pointing an <img> at a 404.
+export async function screenshotExists(batchId: number): Promise<boolean> {
+    try {
+        const stats = await stat(screenshotFilePath(batchId));
+        return stats.isFile() && stats.size > 0;
+    } catch {
+        return false;
+    }
 }
 
 function isBlockedVideoRequest(url: string): boolean {

--- a/src/routes/(app)/dashboard/+page.server.ts
+++ b/src/routes/(app)/dashboard/+page.server.ts
@@ -3,6 +3,7 @@ import {
     ACCEPTED_UPLOAD_TYPES,
     MAX_UPLOAD_BYTES,
     captureScreenshot,
+    screenshotExists,
     storeUploadedScreenshot,
 } from "$lib/server/screenshots";
 import { batches, urls } from "$lib/server/schema";
@@ -39,7 +40,19 @@ export async function load({ locals }) {
         .groupBy(batches.id)
         .orderBy(batches.baseUrl);
 
-    return { batches: rows };
+    // Only report a screenshot the serving endpoint can actually find; a stale
+    // timestamp would otherwise render as a broken image on the card.
+    const withScreenshots = await Promise.all(
+        rows.map(async (row) => ({
+            ...row,
+            screenshotUpdatedAt:
+                row.screenshotUpdatedAt && (await screenshotExists(row.id))
+                    ? row.screenshotUpdatedAt
+                    : null,
+        })),
+    );
+
+    return { batches: withScreenshots };
 }
 
 export const actions = {

--- a/src/routes/(app)/dashboard/+page.svelte
+++ b/src/routes/(app)/dashboard/+page.svelte
@@ -9,6 +9,7 @@
         Check,
         ExternalLink,
         FolderPlus,
+        ImageOff,
         Loader2,
         Plus,
         RotateCw,
@@ -23,6 +24,9 @@
 
     let refreshing = $state<Record<number, boolean>>({});
     let uploading = $state<Record<number, boolean>>({});
+    // Screenshots whose image request failed after the page loaded (the file was
+    // removed, or the request errored) — shown as the placeholder instead.
+    let brokenScreenshots = $state<Record<number, boolean>>({});
 
     let query = $state("");
     let sort = $state<"recent" | "name" | "needs-work">("recent");
@@ -63,7 +67,8 @@
         id: number;
         screenshotUpdatedAt: Date | null;
     }) {
-        if (!batch.screenshotUpdatedAt) return null;
+        if (!batch.screenshotUpdatedAt || brokenScreenshots[batch.id])
+            return null;
         const version = new Date(batch.screenshotUpdatedAt).getTime();
         return `/api/screenshot/${batch.id}?v=${version}`;
     }
@@ -206,12 +211,19 @@
                                                 alt={`${batch.baseUrl} screenshot`}
                                                 class="aspect-video w-full bg-zinc-200 object-cover transition group-hover:opacity-90"
                                                 loading="lazy"
+                                                onerror={() =>
+                                                    (brokenScreenshots[
+                                                        batch.id
+                                                    ] = true)}
                                             />
                                         {:else}
                                             <div
-                                                class="flex aspect-video w-full items-center justify-center bg-zinc-200 text-sm text-zinc-500"
+                                                class="flex aspect-video w-full flex-col items-center justify-center gap-1 bg-zinc-200 text-sm text-zinc-500"
                                             >
-                                                No screenshot yet
+                                                <ImageOff class="size-5" />
+                                                {brokenScreenshots[batch.id]
+                                                    ? "Screenshot unavailable"
+                                                    : "No screenshot yet"}
                                             </div>
                                         {/if}
                                     </a>
@@ -229,6 +241,11 @@
                                                     await update({
                                                         reset: true,
                                                     });
+                                                    // Give the new image a
+                                                    // chance to load.
+                                                    delete brokenScreenshots[
+                                                        batch.id
+                                                    ];
                                                     uploading[batch.id] = false;
                                                 };
                                             }}
@@ -281,6 +298,9 @@
                                                 refreshing[batch.id] = true;
                                                 return async ({ update }) => {
                                                     await update();
+                                                    delete brokenScreenshots[
+                                                        batch.id
+                                                    ];
                                                     refreshing[batch.id] = false;
                                                 };
                                             }}


### PR DESCRIPTION
## What changed

The dashboard decided whether to render a thumbnail from `batches.screenshotUpdatedAt` alone, while the image itself is a file under `SCREENSHOTS_DIR`. When the two drift, the card rendered an `<img>` pointing at a 404 from `/api/screenshot/[id]` and the browser showed a broken image.

Two ways they drift:

1. `bun db:copy-production-to-local` copies rows only — `scripts/copy-production-db-to-local.ts` has no screenshot handling — so every batch captured in production arrives locally with a timestamp and no file.
2. In production the images only survive redeploys if `SCREENSHOTS_DIR` is a mounted persistent volume; if it isn't, the database keeps pointing at images that are gone.

- `screenshotExists()` in `src/lib/server/screenshots.ts` — stat the file, require it to be a non-empty file.
- Dashboard `load` clears `screenshotUpdatedAt` for batches whose file is not on disk, so those cards render the existing placeholder instead of an `<img>`.
- The `<img>` falls back to the placeholder `onerror` (covers a file removed after the page loaded, or a transient error) and reads "Screenshot unavailable" in that case rather than "No screenshot yet". The flag is cleared after a successful refresh or upload so the new image gets a chance to load.
- Placeholder gained an `ImageOff` icon.
- README documents the DB/disk drift under Screenshots.

## Why

A dashboard full of broken image icons, and no placeholder for the failure case.

## How to test

1. `docker compose up -d && bun run db:migrate && bun run dev`
2. Pick a batch that has a screenshot and delete its file: `rm .screenshots/<id>.jpg` (leave `screenshot_updated_at` set in the database).
3. Load `/dashboard` — that card shows the "No screenshot yet" placeholder, not a broken image. Batches whose file is present still render their thumbnail.
4. Click the refresh button on the placeholder card — it re-captures and the thumbnail appears.
5. For the client-side fallback, block `/api/screenshot/**` in devtools and reload: cards show "Screenshot unavailable" with no broken images.

Verified locally with three batches (file present / timestamp but no file / no timestamp) and a Playwright run aborting all `/api/screenshot/**` requests: 0 broken `<img>` elements. `bun run check` and `bun run lint` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The dashboard now detects missing or inaccessible screenshots and displays a clear unavailable placeholder instead of repeatedly showing a broken image.
  * Screenshots can be retried after a successful upload or refresh, restoring normal display automatically.

* **Documentation**
  * Added deployment guidance covering screenshot timestamps, stored image files, database copies, volume loss, and placeholder/refresh behavior.

* **Chores**
  * Updated development tooling and supporting packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->